### PR TITLE
Strengthen GitHub workflow handoffs before archive

### DIFF
--- a/.codex/skills/apply/SKILL.md
+++ b/.codex/skills/apply/SKILL.md
@@ -50,7 +50,7 @@ Apply tasks from an OpenSpec change.
    - If `state: "blocked"` (missing artifacts): show the missing artifacts and stop. Suggest the exact previous workflow step instead:
      - missing proposal/specs/design/tasks -> run `/propose <name>` or `/design <name>` as appropriate
      - missing tests -> run `/tdd <name>` or get explicit human approval to skip test generation for this change
-   - If `state: "all_done"`: confirm implementation is complete, suggest `/review <name>` before archive
+   - If `state: "all_done"`: confirm implementation is complete. For GitHub-backed changes, suggest `/github:create-pr <name>` before `/review`. For explicit local-only changes, suggest `/review <name>` and record that GitHub issue/PR evidence was intentionally skipped.
    - Otherwise: proceed to implementation
 
 4. **Read context files**
@@ -91,7 +91,7 @@ Apply tasks from an OpenSpec change.
    Display:
    - Tasks completed this session
    - Overall progress: "N/M tasks complete"
-   - If all done: suggest `/review <name>` before archive
+   - If all done: for GitHub-backed changes, suggest `/github:create-pr <name>` before `/review`; for explicit local-only changes, suggest `/review <name>` and record the accepted GitHub evidence bypass.
    - If paused: explain why and wait for guidance
 
 **Output During Implementation**
@@ -122,7 +122,9 @@ Working on task 4/7: <task description>
 - [x] Task 2
 ...
 
-All tasks complete. Run `/review <change-name>` before archive.
+All tasks complete. For GitHub-backed changes, run `/github:create-pr <change-name>` before `/review <change-name>`.
+
+If the human explicitly accepted local-only work, run `/review <change-name>` and record that GitHub issue/PR evidence was intentionally skipped.
 ```
 
 **Output On Pause (Issue Encountered)**

--- a/.codex/skills/archive/SKILL.md
+++ b/.codex/skills/archive/SKILL.md
@@ -115,7 +115,48 @@ Archive a completed change in the experimental workflow.
    - blocking findings state
    - residual risk summary from `review.md`
 
-5. **Assess delta spec sync state**
+5. **Check GitHub delivery evidence**
+
+   Archive must fail closed for GitHub-backed changes when durable GitHub
+   delivery evidence is missing.
+
+   Determine whether the change is GitHub-backed or explicit local-only by
+   checking, in order:
+   - human-provided issue or PR target in the request or conversation
+   - issue or PR links in the change artifacts, `review.md`, or task notes
+   - current branch or git remote context that clearly identifies a PR-backed
+     branch
+   - explicit local-only acceptance documented in the artifacts or `review.md`
+
+   **For GitHub-backed changes, require durable PR or merge evidence:**
+   - PR URL or number
+   - issue linkage when known
+   - merge record or explicit handoff from `/github:merge <pr>`
+
+   **Block archive when:**
+   - the change is GitHub-backed and no PR or merge evidence is available
+   - `/review` passed but no PR, merge record, or accepted local-only bypass
+     exists
+   - GitHub-backed versus local-only status is ambiguous and no explicit
+     local-only acceptance is documented
+
+   Blocked message:
+
+   ```text
+   Archive blocked: GitHub delivery evidence is missing. Run `/github:merge <pr>` or document an explicit local-only exception with residual risk.
+   ```
+
+   **For explicit local-only or legacy bypass:**
+   - require documented human acceptance
+   - require residual risk in `review.md`
+   - show the bypass reason before final archive action
+
+   Before proceeding, show:
+   - PR link or merge record for GitHub-backed changes
+   - issue linkage when known
+   - local-only or legacy bypass reason when applicable
+
+6. **Assess delta spec sync state**
 
    Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
 
@@ -130,7 +171,7 @@ Archive a completed change in the experimental workflow.
 
    If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
 
-6. **Perform the archive**
+7. **Perform the archive**
 
    Create the archive directory if it doesn't exist:
 
@@ -148,12 +189,13 @@ Archive a completed change in the experimental workflow.
    mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
    ```
 
-7. **Display summary**
+8. **Display summary**
 
    Show archive completion summary including:
    - Change name
    - Schema that was used
    - Archive location
+   - GitHub delivery evidence or documented local-only bypass
    - Whether specs were synced (if applicable)
    - Note about any warnings (incomplete artifacts/tasks)
 
@@ -166,6 +208,7 @@ Archive a completed change in the experimental workflow.
 **Schema:** <schema-name>
 **Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
 **Specs:** ✓ Synced to main specs (or "No delta specs" or "Sync skipped")
+**GitHub:** PR/merge evidence verified (or "Local-only bypass documented")
 
 All artifacts complete. All tasks complete.
 ```
@@ -176,6 +219,8 @@ All artifacts complete. All tasks complete.
 - Use artifact graph (openspec status --json) for completion checking
 - Don't block archive on artifact/task warnings - just inform and confirm
 - Do block archive on review gate failures: missing, malformed, stale, non-pass, or blocking `review.md`
+- Do block archive for GitHub-backed changes when PR or merge evidence is missing
+- Do require documented human acceptance and residual risk before treating a change as local-only
 - Preserve .openspec.yaml when moving to archive (it moves with the directory)
 - Show clear summary of what happened
 - If sync is requested, use openspec-sync-specs approach (agent-driven)

--- a/.codex/skills/review/SKILL.md
+++ b/.codex/skills/review/SKILL.md
@@ -10,7 +10,7 @@ metadata:
 
 Review an applied OpenSpec change before archive.
 
-`/review` is a quality gate between `/apply` and `/archive`. It reviews implementation against approved artifacts and writes `openspec/changes/<name>/review.md`.
+`/review` is a quality gate after implementation and PR publication. It reviews implementation against approved artifacts and writes `openspec/changes/<name>/review.md`. For GitHub-backed changes, passed review must be posted to the PR before merge/archive.
 
 ## Input
 
@@ -124,6 +124,8 @@ If no findings exist, say that explicitly under `## Findings`.
 
 If no tests/checks were run, record that under `## Tests Run` and explain under `## Residual Risk`.
 
+If GitHub-backed versus explicit local-only status cannot be determined, record that ambiguity under `## Residual Risk` and route the handoff toward GitHub evidence rather than archive.
+
 ### Legacy Bypass
 
 For a pre-gate legacy change, a maintainer may document bypass in `review.md`. Bypass still requires:
@@ -147,7 +149,9 @@ After writing `review.md`, summarize:
 If verdict is pass, say:
 
 ```text
-Review passed. Run `/archive <name>` when ready.
+Review passed. For GitHub-backed changes, run `/github:post-review <pr>` and then `/github:sync-review <pr>` before merge/archive.
+
+If this is an explicit local-only change, run `/archive <name>` only after the local-only bypass and residual risk are documented.
 ```
 
 If verdict is fail, say:

--- a/openspec/changes/strengthen-github-workflow-handoffs/.openspec.yaml
+++ b/openspec/changes/strengthen-github-workflow-handoffs/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-custom
+created: 2026-05-03

--- a/openspec/changes/strengthen-github-workflow-handoffs/design.md
+++ b/openspec/changes/strengthen-github-workflow-handoffs/design.md
@@ -1,0 +1,101 @@
+## Context
+
+Current state:
+
+- GitHub orchestration skills exist for issue creation, PR creation, review posting, review sync, comment handling, and merge.
+- Core OpenSpec skills still hand off `/apply -> /review -> /archive`.
+- Active specs do not include `github-workflow` or `github-orchestration-skills`, even though archived changes defined those contracts.
+
+This creates a workflow gap: a change can satisfy local review and archive without durable GitHub PR or merge evidence.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make GitHub-backed delivery the default handoff path after exploration.
+- Route completed implementation through PR creation before local review.
+- Route passed local review through review posting, PR review sync, comment handling, and merge before archive.
+- Make archive fail closed when GitHub-backed work lacks PR or merge evidence.
+- Preserve an explicit local-only escape hatch for small or private changes.
+
+**Non-Goals:**
+
+- Implement GitHub Actions, labels, templates, or project automation.
+- Auto-sync OpenSpec task state to GitHub.
+- Require GitHub for every trivial local-only note or experiment.
+- Replace OpenSpec artifacts with GitHub issue or PR text.
+
+## Decisions
+
+### Decision: GitHub-backed is the default durable path
+
+The standard workflow becomes:
+
+```text
+/explore
+  -> /github:create-issue
+  -> /brief or /propose
+  -> /tdd
+  -> /apply
+  -> /github:create-pr
+  -> /review
+  -> /github:post-review
+  -> /github:sync-review
+  -> /github:address-comments if needed
+  -> /github:merge
+  -> /archive
+```
+
+Rationale: GitHub is the durable source of truth for issue intent, PR review state, merge evidence, and collaboration. OpenSpec remains the structured artifact layer.
+
+Alternative considered: keep GitHub skills optional. Rejected because optional skills do not satisfy a source-of-truth contract.
+
+### Decision: Core skills hand off, GitHub skills own GitHub work
+
+Core OpenSpec skills should not absorb all GitHub behavior. They should point to the right GitHub orchestration skill at workflow boundaries:
+
+- `/apply` complete -> `/github:create-pr` for GitHub-backed changes.
+- `/review` pass -> `/github:post-review`, then `/github:sync-review`.
+- `/archive` -> require merge evidence or explicit local-only bypass.
+
+Rationale: this keeps core skills focused while preventing bypass at key handoff points.
+
+Alternative considered: rewrite `/apply`, `/review`, and `/archive` to fully manage GitHub. Rejected because it duplicates the dedicated GitHub skill contracts.
+
+### Decision: Local-only must be explicit
+
+Small changes can skip GitHub only when the human explicitly accepts local-only work and the handoff/review/archive records the missing GitHub evidence as accepted residual risk.
+
+Rationale: not every change deserves full GitHub ceremony, but implicit bypass is the failure mode this change is fixing.
+
+Alternative considered: require GitHub for every change. Rejected because it adds friction for harmless local-only maintenance.
+
+### Decision: Archive is the final enforcement point
+
+Archive must continue to parse `review.md` metadata, then add GitHub evidence checks for GitHub-backed changes.
+
+Rationale: `/archive` is the last durable state transition. If it accepts missing PR or merge evidence silently, earlier handoffs become advisory only.
+
+Alternative considered: rely on `/github:merge` to hand off correctly. Rejected because users can still call `/archive` directly.
+
+## Risks / Trade-offs
+
+- [Risk] Extra workflow friction for tiny changes -> Mitigation: allow explicit local-only bypass with documented residual risk.
+- [Risk] GitHub evidence detection may be ambiguous -> Mitigation: block and ask for PR/issue link instead of guessing.
+- [Risk] Core and GitHub skills drift again -> Mitigation: active specs must include both `github-workflow` and `github-orchestration-skills`.
+- [Risk] Existing archived changes lack PR evidence -> Mitigation: apply the stricter gate to active GitHub-backed changes and allow documented legacy/local bypass.
+
+## Migration Plan
+
+1. Add active GitHub workflow specs.
+2. Update core skill handoff text and schema done instructions.
+3. Update archive guidance to require GitHub delivery evidence for GitHub-backed changes.
+4. Verify active docs and skills no longer route directly from `/review` pass to `/archive` for GitHub-backed changes.
+
+Rollback: revert the skill/spec updates. Existing OpenSpec review gate remains intact.
+
+## Open Questions
+
+- How should a change declare `GitHub-backed` versus `local-only`: issue link in artifacts, PR link in handoff, or explicit metadata?
+- Should `/propose` suggest `/github:create-issue` when no issue exists, or should that remain an `/explore` outcome?
+- Should archive verify merge evidence through GitHub MCP/plugin, local git history, PR URL in artifacts, or a combination?

--- a/openspec/changes/strengthen-github-workflow-handoffs/proposal.md
+++ b/openspec/changes/strengthen-github-workflow-handoffs/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+GitHub orchestration skills now exist, but the core OpenSpec handoffs still allow a completed change to move from `/review` directly to `/archive`. That weakens the GitHub source-of-truth workflow because PR creation, review posting, PR feedback sync, merge evidence, and issue linkage can be skipped.
+
+## What Changes
+
+- Strengthen core workflow handoffs so GitHub-backed changes route through GitHub orchestration steps before archive.
+- Update post-apply and post-review guidance to include PR creation, review posting, review sync, comment handling, and merge gates.
+- Update archive readiness requirements so GitHub-backed changes require durable PR or merge evidence before archive.
+- Promote the GitHub workflow contract into active specs instead of leaving it only in archived change artifacts.
+- Keep small local-only changes possible through explicit human acceptance when GitHub tracking is not needed.
+
+## Capabilities
+
+### New Capabilities
+
+- `github-workflow`: Defines GitHub Issues, Pull Requests, branches, commits, and OpenSpec artifacts as the durable delivery workflow contract.
+- `github-orchestration-skills`: Defines the GitHub skill set, handoff contract, and read-only versus mutating workflow boundaries.
+
+### Modified Capabilities
+
+- `code-skill`: Post-apply handoff changes from review-only guidance to GitHub-aware PR and review routing.
+- `review-quality-gate`: Archive readiness changes to include GitHub PR or merge evidence for GitHub-backed changes.
+
+## Impact
+
+- Affected skill instructions: `.codex/skills/apply/SKILL.md`, `.codex/skills/review/SKILL.md`, `.codex/skills/archive/SKILL.md`, and possibly `.codex/skills/propose/SKILL.md`.
+- Affected schema guidance: `openspec/schemas/spec-driven-custom/schema.yaml`.
+- Affected specs: active `openspec/specs/` entries for GitHub workflow and existing workflow gates.
+- No new runtime dependency expected.

--- a/openspec/changes/strengthen-github-workflow-handoffs/review.md
+++ b/openspec/changes/strengthen-github-workflow-handoffs/review.md
@@ -1,0 +1,35 @@
+verdict: pass
+blocking_findings: none
+reviewed_ref: 4b1a115638c6536bf65602f746bbf1c55eafbd48
+reviewed_diff: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+reviewed_at: 2026-05-03T15:20:20Z
+
+## Findings
+
+No blocking findings found.
+
+The implementation matches the approved artifacts:
+
+- active `github-workflow` and `github-orchestration-skills` specs were added
+- `/apply` routes GitHub-backed completed work to `/github:create-pr` before `/review`
+- `/review` routes passing GitHub-backed changes to `/github:post-review` and `/github:sync-review`
+- `/archive` now requires GitHub PR or merge evidence for GitHub-backed changes
+- local-only bypass requires explicit human acceptance and residual risk
+
+## Tests Run
+
+- `openspec validate strengthen-github-workflow-handoffs`
+- `openspec validate --specs`
+- `openspec validate --changes`
+- `rg -n 'Review passed\\. Run `/archive|All tasks complete\\. Run `/review|ready to archive|/apply -> /review -> /archive|Run `/archive <name>` when ready|Run `/review <name>` before archive' .codex/skills openspec/schemas openspec/specs`
+
+## Residual Risk
+
+- GitHub-backed versus explicit local-only detection is still instruction-driven, not runtime-enforced.
+- `/github:create-pr` branch auto-creation is tracked separately in issue #1 and change `issue-1-improve-create-pr-branch-flow`.
+- The workspace contains unrelated untracked files under `openspec/changes/issue-1-improve-create-pr-branch-flow/`; they were not included in the reviewed tracked diff for this change.
+- GitHub PR evidence exists for this change via PR #3: https://github.com/haipd91/WorkLoop/pull/3
+
+## Verdict
+
+Pass. The change satisfies the approved scope and preserves the intended GitHub-backed handoff gates before archive.

--- a/openspec/changes/strengthen-github-workflow-handoffs/specs/code-skill/spec.md
+++ b/openspec/changes/strengthen-github-workflow-handoffs/specs/code-skill/spec.md
@@ -1,16 +1,4 @@
-## Purpose
-Define how `/apply` gathers implementation context before working through a change's tasks.
-## Requirements
-### Requirement: Read tests directory as implementation context
-The system SHALL check for `openspec/changes/<name>/tests/` before starting implementation through `/apply` and use its contents as context to guide each task's implementation.
-
-#### Scenario: Tests directory exists
-- **WHEN** `/apply` starts and `openspec/changes/<name>/tests/` exists
-- **THEN** the skill reads all test files and uses them as implementation context for each task
-
-#### Scenario: Tests directory does not exist
-- **WHEN** `/apply` starts and no `tests/` directory is found
-- **THEN** the skill proceeds with implementation using only proposal, design, and tasks artifacts
+## MODIFIED Requirements
 
 ### Requirement: Hand off to /review after implementation
 The `/apply` skill SHALL direct users to publish or update GitHub PR evidence before `/review` when the change is GitHub-backed, and SHALL NOT imply the change is ready to archive.

--- a/openspec/changes/strengthen-github-workflow-handoffs/specs/github-orchestration-skills/spec.md
+++ b/openspec/changes/strengthen-github-workflow-handoffs/specs/github-orchestration-skills/spec.md
@@ -1,0 +1,49 @@
+## ADDED Requirements
+
+### Requirement: GitHub orchestration skills
+WorkLoop SHALL provide dedicated GitHub orchestration skill instructions that operate around the existing OpenSpec workflow.
+
+#### Scenario: Required skill set exists
+- **WHEN** the GitHub orchestration workflow is implemented
+- **THEN** WorkLoop MUST include skill instructions for `/github:create-issue`, `/github:create-pr`, `/github:post-review`, `/github:sync-review`, `/github:address-comments`, and `/github:merge`
+
+#### Scenario: Core skills hand off to orchestration skills
+- **WHEN** core OpenSpec skills finish stages that require GitHub durability
+- **THEN** those skills MUST hand off to the appropriate GitHub orchestration skill instead of bypassing GitHub gates
+
+### Requirement: Handoff contract
+Every GitHub orchestration skill SHALL output a handoff that tells the human current state, completed work, required human action, next command, blockers, and links.
+
+#### Scenario: Successful GitHub step
+- **WHEN** a GitHub orchestration skill completes successfully
+- **THEN** its output MUST include `Current state`, `Done`, `Needs human`, `Next command`, `Blockers`, and `Links`
+
+#### Scenario: Blocked GitHub step
+- **WHEN** a GitHub orchestration skill cannot complete because of missing context, missing permission, unavailable GitHub access, CI failure, or ambiguous review feedback
+- **THEN** it MUST still output the same handoff fields and identify the blocker explicitly
+
+### Requirement: End-to-end GitHub handoff order
+WorkLoop SHALL document and enforce the expected GitHub-backed handoff sequence around OpenSpec work.
+
+#### Scenario: Standard GitHub-backed workflow
+- **WHEN** a tracked WorkLoop change moves from discovery to archive
+- **THEN** the workflow MUST route through `/explore`, `/github:create-issue`, `/brief` or `/propose`, `/tdd`, `/apply`, `/github:create-pr`, `/review`, `/github:post-review`, `/github:sync-review`, `/github:address-comments` when needed, `/github:merge`, and `/archive`
+
+#### Scenario: Review feedback is clean
+- **WHEN** `/github:sync-review` finds no unresolved comments, requested changes, or failing required checks
+- **THEN** the next handoff MUST be `/github:merge`
+
+#### Scenario: Review feedback requires changes
+- **WHEN** `/github:sync-review` finds actionable unresolved feedback
+- **THEN** the next handoff MUST be `/github:address-comments` before merge
+
+### Requirement: MCP GitHub usage
+GitHub orchestration skills SHALL use the MCP GitHub/plugin path for GitHub operations and SHALL NOT ask users to paste tokens or secrets into chat.
+
+#### Scenario: GitHub operation requested
+- **WHEN** a GitHub orchestration skill needs to read or mutate GitHub state
+- **THEN** the skill MUST use the available MCP GitHub/plugin capability or fail with a handoff blocker
+
+#### Scenario: Token provided in chat
+- **WHEN** a user attempts to provide a personal token or secret in chat
+- **THEN** the skill MUST reject chat-based secret handling and direct the user to use connector, environment, or configuration-based setup

--- a/openspec/changes/strengthen-github-workflow-handoffs/specs/github-workflow/spec.md
+++ b/openspec/changes/strengthen-github-workflow-handoffs/specs/github-workflow/spec.md
@@ -1,0 +1,64 @@
+## ADDED Requirements
+
+### Requirement: GitHub source of truth
+WorkLoop SHALL treat the GitHub repository as the durable source of truth for delivery state, including issue intent, pull request review state, committed OpenSpec artifacts, and merge/archive history.
+
+#### Scenario: Durable workflow state
+- **WHEN** a WorkLoop change is created from a GitHub-tracked work item
+- **THEN** the issue, branch, PR, commits, and OpenSpec artifacts MUST provide enough durable context to understand the work without relying on chat history
+
+#### Scenario: Chat-only decision rejected
+- **WHEN** a material scope, design, or risk decision exists only in chat
+- **THEN** the workflow MUST capture that decision in a GitHub issue, PR, or committed OpenSpec artifact before the work is considered ready for review
+
+### Requirement: Issue intake lifecycle
+WorkLoop SHALL define GitHub Issues as the primary intake and backlog artifact for user-visible work, defects, workflow changes, and durable follow-up items.
+
+#### Scenario: Issue starts a change
+- **WHEN** an issue is selected for structured delivery
+- **THEN** the workflow MUST create or reference an OpenSpec change that captures scope, requirements, design, tasks, tests, and review artifacts as needed
+
+#### Scenario: Explore precedes issue creation
+- **WHEN** exploratory discussion identifies work worth tracking durably
+- **THEN** the workflow MUST hand off to `/github:create-issue` before creating implementation-ready OpenSpec tasks unless the human explicitly accepts local-only work
+
+#### Scenario: Issue lacks acceptance criteria
+- **WHEN** an issue does not include enough problem context, expected outcome, or acceptance criteria
+- **THEN** the workflow MUST ask for clarification or add missing context before creating implementation tasks
+
+### Requirement: OpenSpec artifact ownership
+WorkLoop SHALL define OpenSpec artifacts as repository-committed planning, specification, task, test, and review records that support GitHub-tracked delivery.
+
+#### Scenario: Planning artifact ownership
+- **WHEN** a change uses OpenSpec planning
+- **THEN** proposal, specs, design, tasks, tests, and review artifacts MUST be committed to the repository as part of the branch or PR that represents the work
+
+#### Scenario: Artifact role separation
+- **WHEN** documenting workflow state
+- **THEN** GitHub Issues MUST own demand and priority, Pull Requests MUST own review and delivery evidence, and OpenSpec artifacts MUST own structured scope, requirements, design, tasks, tests, and quality gates
+
+### Requirement: Branch and pull request lifecycle
+WorkLoop SHALL define branch and pull request conventions that connect GitHub work items to OpenSpec changes.
+
+#### Scenario: Branch created for issue-backed work
+- **WHEN** a branch is created for a GitHub issue
+- **THEN** the branch name MUST include the `codex/` prefix and a stable issue or change slug when practical
+
+#### Scenario: Pull request created for delivery
+- **WHEN** a pull request is opened for a WorkLoop change
+- **THEN** the PR body MUST summarize the problem, approach, verification, linked issue, and relevant OpenSpec change path
+
+### Requirement: Quality gates
+WorkLoop SHALL define quality gates before PR readiness, merge, and OpenSpec archive.
+
+#### Scenario: PR readiness gate
+- **WHEN** a PR is marked ready for review
+- **THEN** the workflow MUST verify that scope, requirements, implementation plan, and verification evidence are represented in GitHub or committed OpenSpec artifacts
+
+#### Scenario: Archive gate
+- **WHEN** an OpenSpec change is archived after delivery
+- **THEN** the workflow MUST verify that review requirements are satisfied and that the GitHub PR or merge record provides durable delivery evidence
+
+#### Scenario: Local-only exception
+- **WHEN** a change intentionally skips GitHub issue or PR tracking
+- **THEN** the workflow MUST record explicit human acceptance and residual risk before review or archive treats the missing GitHub evidence as non-blocking

--- a/openspec/changes/strengthen-github-workflow-handoffs/specs/review-quality-gate/spec.md
+++ b/openspec/changes/strengthen-github-workflow-handoffs/specs/review-quality-gate/spec.md
@@ -1,0 +1,27 @@
+## MODIFIED Requirements
+
+### Requirement: Preserve human archive acceptance
+Archive SHALL present review verdict, residual risk, and GitHub delivery evidence before final archive action so the human owns final risk acceptance.
+
+#### Scenario: Review and GitHub evidence pass before archive
+- **WHEN** archive starts and review gate checks pass for a GitHub-backed change
+- **THEN** archive presents the review verdict, residual risk, PR link or merge record, and issue linkage before finalizing the change
+
+#### Scenario: Local-only archive exception is documented
+- **WHEN** archive starts for a change where the human explicitly accepted local-only work
+- **THEN** archive presents the review verdict, residual risk, and documented GitHub bypass reason before finalizing the change
+
+### Requirement: Require GitHub delivery evidence before archive
+Archive SHALL block GitHub-backed changes unless durable GitHub PR or merge evidence is available.
+
+#### Scenario: GitHub-backed change has merge evidence
+- **WHEN** archive starts for a GitHub-backed change with passing review metadata and durable PR or merge evidence
+- **THEN** archive may continue to remaining archive checks
+
+#### Scenario: GitHub-backed change lacks merge evidence
+- **WHEN** archive starts for a GitHub-backed change without durable PR or merge evidence
+- **THEN** archive is blocked with instructions to run `/github:merge <pr>` or document an explicit local-only exception
+
+#### Scenario: Review passes but GitHub evidence is missing
+- **WHEN** `/review` has passed but no PR, merge record, or accepted local-only bypass exists
+- **THEN** archive remains blocked because local review evidence alone is insufficient for GitHub-backed delivery

--- a/openspec/changes/strengthen-github-workflow-handoffs/tasks.md
+++ b/openspec/changes/strengthen-github-workflow-handoffs/tasks.md
@@ -1,0 +1,26 @@
+## 1. Active GitHub Specs
+
+- [x] 1.1 Sync `github-workflow` into active `openspec/specs/github-workflow/spec.md`.
+- [x] 1.2 Sync `github-orchestration-skills` into active `openspec/specs/github-orchestration-skills/spec.md`.
+- [x] 1.3 Verify active specs describe `/explore -> /github:create-issue -> OpenSpec -> GitHub PR/review/merge -> /archive`.
+
+## 2. Core Handoff Updates
+
+- [x] 2.1 Update `/apply` handoff so GitHub-backed completed implementation routes to `/github:create-pr <change-name>` before `/review`.
+- [x] 2.2 Update `/review` pass handoff so GitHub-backed changes route to `/github:post-review <pr>` and `/github:sync-review <pr>` before merge/archive.
+- [x] 2.3 Update schema apply done instruction so generated OpenSpec apply guidance matches the GitHub-aware handoff.
+- [x] 2.4 Preserve explicit local-only exception language for changes where the human accepts skipping GitHub.
+
+## 3. Archive Gate Updates
+
+- [x] 3.1 Update `/archive` guidance to require durable PR or merge evidence for GitHub-backed changes.
+- [x] 3.2 Define how archive blocks when review passes but PR/merge evidence is missing.
+- [x] 3.3 Preserve existing `review.md` metadata, stale diff, and blocking findings checks.
+- [x] 3.4 Document local-only or legacy bypass handling with residual risk.
+
+## 4. Verification
+
+- [x] 4.1 Run OpenSpec validation for `strengthen-github-workflow-handoffs`.
+- [x] 4.2 Search active skills and schema guidance for direct `/review` pass to `/archive` bypasses.
+- [x] 4.3 Verify GitHub orchestration skills still own GitHub operations and core skills only hand off.
+- [x] 4.4 Record any remaining ambiguity around GitHub-backed detection as residual risk for `/review`.

--- a/openspec/changes/strengthen-github-workflow-handoffs/tests/1-active-github-specs.md
+++ b/openspec/changes/strengthen-github-workflow-handoffs/tests/1-active-github-specs.md
@@ -1,0 +1,48 @@
+# Test Scenario: 1 active-github-specs
+
+- Source tasks:
+  - 1.1 Sync `github-workflow` into active `openspec/specs/github-workflow/spec.md`.
+  - 1.2 Sync `github-orchestration-skills` into active `openspec/specs/github-orchestration-skills/spec.md`.
+  - 1.3 Verify active specs describe `/explore -> /github:create-issue -> OpenSpec -> GitHub PR/review/merge -> /archive`.
+- Related requirements:
+  - GitHub source of truth
+  - Issue intake lifecycle
+  - OpenSpec artifact ownership
+  - End-to-end GitHub handoff order
+- Assumptions:
+  - Active specs under `openspec/specs/` are the durable source after archive.
+  - Archived change specs are useful source material but not active requirements.
+
+## Happy Path
+
+- Khi implementation hoàn tất sync specs
+- Thì `openspec/specs/github-workflow/spec.md` tồn tại và mô tả GitHub là durable source of truth.
+- Thì `openspec/specs/github-orchestration-skills/spec.md` tồn tại và mô tả skill set GitHub.
+- Thì active specs có flow chuẩn: `/explore -> /github:create-issue -> /brief|/propose -> /tdd -> /apply -> /github:create-pr -> /review -> /github:post-review -> /github:sync-review -> /github:address-comments nếu cần -> /github:merge -> /archive`.
+
+## Edge Cases
+
+- Khi archived GitHub specs và change delta specs khác nhau
+- Thì active specs phải theo delta specs của change hiện tại, không copy mù từ archive.
+
+- Khi local-only exception được mô tả
+- Thì exception phải yêu cầu human acceptance và residual risk, không biến GitHub workflow thành optional mặc định.
+
+## Error Cases
+
+- Khi `github-workflow` hoặc `github-orchestration-skills` chỉ tồn tại trong `openspec/changes/archive/`
+- Thì verification phải fail vì active specs chưa có source-of-truth contract.
+
+- Khi active specs thiếu `/explore` hoặc `/github:create-issue` trong flow chuẩn
+- Thì verification phải fail vì discovery-to-issue handoff chưa được capture.
+
+## Expected Outcomes
+
+- Active specs chứa GitHub workflow contract.
+- Active specs không làm suy yếu OpenSpec review gate hiện có.
+- GitHub-backed default và local-only exception được phân biệt rõ.
+
+## Notes for Implementation
+
+- Ưu tiên tạo spec active mới từ delta specs trong change.
+- Sau sync, chạy OpenSpec validation cho change.

--- a/openspec/changes/strengthen-github-workflow-handoffs/tests/2-core-handoff-updates.md
+++ b/openspec/changes/strengthen-github-workflow-handoffs/tests/2-core-handoff-updates.md
@@ -1,0 +1,54 @@
+# Test Scenario: 2 core-handoff-updates
+
+- Source tasks:
+  - 2.1 Update `/apply` handoff so GitHub-backed completed implementation routes to `/github:create-pr <change-name>` before `/review`.
+  - 2.2 Update `/review` pass handoff so GitHub-backed changes route to `/github:post-review <pr>` and `/github:sync-review <pr>` before merge/archive.
+  - 2.3 Update schema apply done instruction so generated OpenSpec apply guidance matches the GitHub-aware handoff.
+  - 2.4 Preserve explicit local-only exception language for changes where the human accepts skipping GitHub.
+- Related requirements:
+  - Hand off to /review after implementation
+  - Core skills hand off to orchestration skills
+  - End-to-end GitHub handoff order
+- Assumptions:
+  - Core OpenSpec skills should hand off to GitHub skills, not implement all GitHub operations themselves.
+  - GitHub-backed is default unless local-only is explicitly accepted.
+
+## Happy Path
+
+- Khi `/apply` hoàn tất tasks cho GitHub-backed change
+- Thì output handoff đề xuất `/github:create-pr <change-name>` trước `/review`.
+- Thì output không nói change đã sẵn sàng archive.
+
+- Khi `/review` pass cho GitHub-backed change
+- Thì output handoff đề xuất `/github:post-review <pr>` và `/github:sync-review <pr>`.
+- Thì output không đề xuất `/archive <name>` trực tiếp.
+
+- Khi `openspec instructions apply --change <name> --json` trả state all_done
+- Thì `doneInstruction` route GitHub-backed work sang `/github:create-pr <name>` thay vì archive.
+
+## Edge Cases
+
+- Khi change được human đánh dấu local-only
+- Thì `/apply` có thể hand off `/review <change-name>`, nhưng phải ghi rõ GitHub issue/PR evidence đã được skip có chủ ý.
+
+- Khi PR target chưa rõ sau `/review`
+- Thì handoff phải yêu cầu PR number/URL hoặc `/github:create-pr`, không đoán.
+
+## Error Cases
+
+- Khi `/apply` all_done vẫn chỉ nói `Run /review before archive`
+- Thì verification phải fail vì thiếu GitHub PR handoff.
+
+- Khi `/review` pass vẫn nói `Run /archive when ready`
+- Thì verification phải fail vì bỏ qua post-review, sync-review, merge.
+
+## Expected Outcomes
+
+- Core skills đóng vai trò điều hướng workflow.
+- GitHub operations vẫn thuộc GitHub orchestration skills.
+- Không còn đường mặc định `/apply -> /review -> /archive` cho GitHub-backed changes.
+
+## Notes for Implementation
+
+- Kiểm tra `.codex/skills/apply/SKILL.md`, `.codex/skills/review/SKILL.md`, và `openspec/schemas/spec-driven-custom/schema.yaml`.
+- Search active files sau sửa để tìm bypass text còn sót.

--- a/openspec/changes/strengthen-github-workflow-handoffs/tests/3-archive-gate-updates.md
+++ b/openspec/changes/strengthen-github-workflow-handoffs/tests/3-archive-gate-updates.md
@@ -1,0 +1,57 @@
+# Test Scenario: 3 archive-gate-updates
+
+- Source tasks:
+  - 3.1 Update `/archive` guidance to require durable PR or merge evidence for GitHub-backed changes.
+  - 3.2 Define how archive blocks when review passes but PR/merge evidence is missing.
+  - 3.3 Preserve existing `review.md` metadata, stale diff, and blocking findings checks.
+  - 3.4 Document local-only or legacy bypass handling with residual risk.
+- Related requirements:
+  - Require GitHub delivery evidence before archive
+  - Preserve human archive acceptance
+  - Preserve phase 1 review metadata gate
+  - Block archive on stale review
+- Assumptions:
+  - Archive is final enforcement point.
+  - GitHub-backed archive requires both local review evidence and durable GitHub evidence.
+
+## Happy Path
+
+- Khi `/archive` chạy cho GitHub-backed change có `review.md` pass, no blocking findings, current reviewed diff, và PR/merge evidence
+- Thì archive tiếp tục các checks còn lại.
+- Thì summary trước archive hiển thị review verdict, residual risk, PR link hoặc merge record, và issue linkage.
+
+- Khi `/archive` chạy cho local-only change có explicit human acceptance
+- Thì archive hiển thị bypass reason và residual risk trước final action.
+
+## Edge Cases
+
+- Khi review graph state là done nhưng `review.md` metadata malformed
+- Thì archive vẫn block theo metadata gate cũ.
+
+- Khi PR exists nhưng merge state không rõ
+- Thì archive block hoặc yêu cầu `/github:merge <pr>`, không tự suy đoán.
+
+- Khi legacy archived-style work không có GitHub evidence
+- Thì archive chỉ cho qua nếu bypass được document rõ.
+
+## Error Cases
+
+- Khi `review.md` pass nhưng không có PR/merge evidence
+- Thì archive phải block.
+
+- Khi current diff khác `reviewed_diff`
+- Thì archive phải block và yêu cầu rerun `/review`, kể cả GitHub evidence tồn tại.
+
+- Khi archive chỉ check `review.md` và không nhắc GitHub evidence cho GitHub-backed work
+- Thì verification phải fail.
+
+## Expected Outcomes
+
+- Archive không còn là đường bypass GitHub workflow.
+- Review metadata gate không bị thay thế hoặc làm yếu.
+- Human thấy rõ risk trước final archive.
+
+## Notes for Implementation
+
+- Cần quyết định minimal evidence source cho implementation đầu tiên: PR URL/path trong artifact/handoff, local git branch/remote, hoặc GitHub MCP/plugin.
+- Nếu chưa thể tự verify GitHub state, block và hỏi PR/merge evidence.

--- a/openspec/changes/strengthen-github-workflow-handoffs/tests/4-verification-and-regression.md
+++ b/openspec/changes/strengthen-github-workflow-handoffs/tests/4-verification-and-regression.md
@@ -1,0 +1,57 @@
+# Test Scenario: 4 verification-and-regression
+
+- Source tasks:
+  - 4.1 Run OpenSpec validation for `strengthen-github-workflow-handoffs`.
+  - 4.2 Search active skills and schema guidance for direct `/review` pass to `/archive` bypasses.
+  - 4.3 Verify GitHub orchestration skills still own GitHub operations and core skills only hand off.
+  - 4.4 Record any remaining ambiguity around GitHub-backed detection as residual risk for `/review`.
+- Related requirements:
+  - Handoff contract
+  - MCP GitHub usage
+  - Require GitHub delivery evidence before archive
+  - Local-only exception
+- Assumptions:
+  - This change is mostly workflow/spec/skill instruction work.
+  - Verification is text/search/validation heavy rather than runnable unit tests.
+
+## Happy Path
+
+- Khi `openspec validate strengthen-github-workflow-handoffs` chạy
+- Thì validation pass.
+
+- Khi search active `.codex/skills` và `openspec/schemas` cho direct archive guidance
+- Thì không có default handoff nào route GitHub-backed work từ `/review` pass thẳng `/archive`.
+
+- Khi review GitHub orchestration skills
+- Thì GitHub read/write operations vẫn nằm trong `/github:*` skills.
+- Thì core skills chỉ hand off và nêu blockers.
+
+## Edge Cases
+
+- Khi text `/archive <name>` vẫn tồn tại trong archive skill hoặc merge skill
+- Thì chỉ fail nếu nó là default bypass trước GitHub merge, không fail nếu là post-merge handoff hợp lệ.
+
+- Khi local-only exception text xuất hiện
+- Thì phải kèm explicit human acceptance và residual risk.
+
+## Error Cases
+
+- Khi validation fail
+- Thì implementation chưa hoàn tất.
+
+- Khi active skill guidance còn câu `Review passed. Run /archive <name> when ready` mà không phân biệt GitHub-backed
+- Thì verification phải fail.
+
+- Khi core skill tự yêu cầu token hoặc tự gọi custom GitHub HTTP client
+- Thì verification phải fail vì vi phạm GitHub orchestration boundary.
+
+## Expected Outcomes
+
+- Change có validation pass.
+- Không còn bypass mặc định cho GitHub-backed work.
+- Residual risk ghi rõ phần chưa tự động detect được GitHub-backed/local-only.
+
+## Notes for Implementation
+
+- Dùng `rg` để kiểm text bypass.
+- Không cần tạo GitHub Actions hoặc issue/PR template trong change này.

--- a/openspec/schemas/spec-driven-custom/schema.yaml
+++ b/openspec/schemas/spec-driven-custom/schema.yaml
@@ -284,5 +284,6 @@ apply:
     Read context files, work through pending tasks, mark complete as you go.
     Pause if you hit blockers or need clarification.
   doneInstruction: |
-    All implementation tasks are complete. Run `/review <name>` before archive.
-    Do not archive until review.md exists, verdict is pass, blocking_findings is none, and the review is current.
+    All implementation tasks are complete. For GitHub-backed changes, run `/github:create-pr <name>` before `/review <name>`.
+    For explicit local-only changes, run `/review <name>` and record that GitHub issue/PR evidence was intentionally skipped.
+    Do not archive until review.md exists, verdict is pass, blocking_findings is none, the review is current, and GitHub PR or merge evidence exists unless a documented local-only exception applies.

--- a/openspec/specs/github-orchestration-skills/spec.md
+++ b/openspec/specs/github-orchestration-skills/spec.md
@@ -1,0 +1,51 @@
+## Purpose
+Define GitHub orchestration skills, handoff contracts, and read-only versus mutating workflow boundaries around the OpenSpec workflow.
+
+## Requirements
+### Requirement: GitHub orchestration skills
+WorkLoop SHALL provide dedicated GitHub orchestration skill instructions that operate around the existing OpenSpec workflow.
+
+#### Scenario: Required skill set exists
+- **WHEN** the GitHub orchestration workflow is implemented
+- **THEN** WorkLoop MUST include skill instructions for `/github:create-issue`, `/github:create-pr`, `/github:post-review`, `/github:sync-review`, `/github:address-comments`, and `/github:merge`
+
+#### Scenario: Core skills hand off to orchestration skills
+- **WHEN** core OpenSpec skills finish stages that require GitHub durability
+- **THEN** those skills MUST hand off to the appropriate GitHub orchestration skill instead of bypassing GitHub gates
+
+### Requirement: Handoff contract
+Every GitHub orchestration skill SHALL output a handoff that tells the human current state, completed work, required human action, next command, blockers, and links.
+
+#### Scenario: Successful GitHub step
+- **WHEN** a GitHub orchestration skill completes successfully
+- **THEN** its output MUST include `Current state`, `Done`, `Needs human`, `Next command`, `Blockers`, and `Links`
+
+#### Scenario: Blocked GitHub step
+- **WHEN** a GitHub orchestration skill cannot complete because of missing context, missing permission, unavailable GitHub access, CI failure, or ambiguous review feedback
+- **THEN** it MUST still output the same handoff fields and identify the blocker explicitly
+
+### Requirement: End-to-end GitHub handoff order
+WorkLoop SHALL document and enforce the expected GitHub-backed handoff sequence around OpenSpec work.
+
+#### Scenario: Standard GitHub-backed workflow
+- **WHEN** a tracked WorkLoop change moves from discovery to archive
+- **THEN** the workflow MUST route through `/explore`, `/github:create-issue`, `/brief` or `/propose`, `/tdd`, `/apply`, `/github:create-pr`, `/review`, `/github:post-review`, `/github:sync-review`, `/github:address-comments` when needed, `/github:merge`, and `/archive`
+
+#### Scenario: Review feedback is clean
+- **WHEN** `/github:sync-review` finds no unresolved comments, requested changes, or failing required checks
+- **THEN** the next handoff MUST be `/github:merge`
+
+#### Scenario: Review feedback requires changes
+- **WHEN** `/github:sync-review` finds actionable unresolved feedback
+- **THEN** the next handoff MUST be `/github:address-comments` before merge
+
+### Requirement: MCP GitHub usage
+GitHub orchestration skills SHALL use the MCP GitHub/plugin path for GitHub operations and SHALL NOT ask users to paste tokens or secrets into chat.
+
+#### Scenario: GitHub operation requested
+- **WHEN** a GitHub orchestration skill needs to read or mutate GitHub state
+- **THEN** the skill MUST use the available MCP GitHub/plugin capability or fail with a handoff blocker
+
+#### Scenario: Token provided in chat
+- **WHEN** a user attempts to provide a personal token or secret in chat
+- **THEN** the skill MUST reject chat-based secret handling and direct the user to use connector, environment, or configuration-based setup

--- a/openspec/specs/github-workflow/spec.md
+++ b/openspec/specs/github-workflow/spec.md
@@ -1,0 +1,66 @@
+## Purpose
+Define how GitHub Issues, Pull Requests, branches, commits, and OpenSpec artifacts form the durable WorkLoop delivery record.
+
+## Requirements
+### Requirement: GitHub source of truth
+WorkLoop SHALL treat the GitHub repository as the durable source of truth for delivery state, including issue intent, pull request review state, committed OpenSpec artifacts, and merge/archive history.
+
+#### Scenario: Durable workflow state
+- **WHEN** a WorkLoop change is created from a GitHub-tracked work item
+- **THEN** the issue, branch, PR, commits, and OpenSpec artifacts MUST provide enough durable context to understand the work without relying on chat history
+
+#### Scenario: Chat-only decision rejected
+- **WHEN** a material scope, design, or risk decision exists only in chat
+- **THEN** the workflow MUST capture that decision in a GitHub issue, PR, or committed OpenSpec artifact before the work is considered ready for review
+
+### Requirement: Issue intake lifecycle
+WorkLoop SHALL define GitHub Issues as the primary intake and backlog artifact for user-visible work, defects, workflow changes, and durable follow-up items.
+
+#### Scenario: Issue starts a change
+- **WHEN** an issue is selected for structured delivery
+- **THEN** the workflow MUST create or reference an OpenSpec change that captures scope, requirements, design, tasks, tests, and review artifacts as needed
+
+#### Scenario: Explore precedes issue creation
+- **WHEN** exploratory discussion identifies work worth tracking durably
+- **THEN** the workflow MUST hand off to `/github:create-issue` before creating implementation-ready OpenSpec tasks unless the human explicitly accepts local-only work
+
+#### Scenario: Issue lacks acceptance criteria
+- **WHEN** an issue does not include enough problem context, expected outcome, or acceptance criteria
+- **THEN** the workflow MUST ask for clarification or add missing context before creating implementation tasks
+
+### Requirement: OpenSpec artifact ownership
+WorkLoop SHALL define OpenSpec artifacts as repository-committed planning, specification, task, test, and review records that support GitHub-tracked delivery.
+
+#### Scenario: Planning artifact ownership
+- **WHEN** a change uses OpenSpec planning
+- **THEN** proposal, specs, design, tasks, tests, and review artifacts MUST be committed to the repository as part of the branch or PR that represents the work
+
+#### Scenario: Artifact role separation
+- **WHEN** documenting workflow state
+- **THEN** GitHub Issues MUST own demand and priority, Pull Requests MUST own review and delivery evidence, and OpenSpec artifacts MUST own structured scope, requirements, design, tasks, tests, and quality gates
+
+### Requirement: Branch and pull request lifecycle
+WorkLoop SHALL define branch and pull request conventions that connect GitHub work items to OpenSpec changes.
+
+#### Scenario: Branch created for issue-backed work
+- **WHEN** a branch is created for a GitHub issue
+- **THEN** the branch name MUST include the `codex/` prefix and a stable issue or change slug when practical
+
+#### Scenario: Pull request created for delivery
+- **WHEN** a pull request is opened for a WorkLoop change
+- **THEN** the PR body MUST summarize the problem, approach, verification, linked issue, and relevant OpenSpec change path
+
+### Requirement: Quality gates
+WorkLoop SHALL define quality gates before PR readiness, merge, and OpenSpec archive.
+
+#### Scenario: PR readiness gate
+- **WHEN** a PR is marked ready for review
+- **THEN** the workflow MUST verify that scope, requirements, implementation plan, and verification evidence are represented in GitHub or committed OpenSpec artifacts
+
+#### Scenario: Archive gate
+- **WHEN** an OpenSpec change is archived after delivery
+- **THEN** the workflow MUST verify that review requirements are satisfied and that the GitHub PR or merge record provides durable delivery evidence
+
+#### Scenario: Local-only exception
+- **WHEN** a change intentionally skips GitHub issue or PR tracking
+- **THEN** the workflow MUST record explicit human acceptance and residual risk before review or archive treats the missing GitHub evidence as non-blocking

--- a/openspec/specs/review-quality-gate/spec.md
+++ b/openspec/specs/review-quality-gate/spec.md
@@ -100,11 +100,30 @@ Archive SHALL be blocked when the implementation state differs from the state re
 - **THEN** `/review` uses the available artifacts and records missing context as residual risk
 
 ### Requirement: Preserve human archive acceptance
-Archive SHALL present review verdict and residual risk before final archive action so the human owns final risk acceptance.
+Archive SHALL present review verdict, residual risk, and GitHub delivery evidence before final archive action so the human owns final risk acceptance.
 
-#### Scenario: Review passes before archive
-- **WHEN** archive starts and review gate checks pass
-- **THEN** archive presents the review verdict and residual risk before finalizing the change
+#### Scenario: Review and GitHub evidence pass before archive
+- **WHEN** archive starts and review gate checks pass for a GitHub-backed change
+- **THEN** archive presents the review verdict, residual risk, PR link or merge record, and issue linkage before finalizing the change
+
+#### Scenario: Local-only archive exception is documented
+- **WHEN** archive starts for a change where the human explicitly accepted local-only work
+- **THEN** archive presents the review verdict, residual risk, and documented GitHub bypass reason before finalizing the change
+
+### Requirement: Require GitHub delivery evidence before archive
+Archive SHALL block GitHub-backed changes unless durable GitHub PR or merge evidence is available.
+
+#### Scenario: GitHub-backed change has merge evidence
+- **WHEN** archive starts for a GitHub-backed change with passing review metadata and durable PR or merge evidence
+- **THEN** archive may continue to remaining archive checks
+
+#### Scenario: GitHub-backed change lacks merge evidence
+- **WHEN** archive starts for a GitHub-backed change without durable PR or merge evidence
+- **THEN** archive is blocked with instructions to run `/github:merge <pr>` or document an explicit local-only exception
+
+#### Scenario: Review passes but GitHub evidence is missing
+- **WHEN** `/review` has passed but no PR, merge record, or accepted local-only bypass exists
+- **THEN** archive remains blocked because local review evidence alone is insufficient for GitHub-backed delivery
 
 ### Requirement: Allow only explicit documented legacy bypass
 Archive SHALL allow bypass for pre-gate legacy changes only when the bypass is documented in the review artifact.


### PR DESCRIPTION
## Problem

GitHub orchestration skills existed, but core OpenSpec handoffs still allowed GitHub-backed work to move from `/review` directly to `/archive`. That could bypass PR creation, review posting, PR feedback sync, merge evidence, and issue linkage.

Closes #2

## Approach

- Add active `github-workflow` and `github-orchestration-skills` specs.
- Update `/apply` guidance so GitHub-backed completed implementation routes to `/github:create-pr` before `/review`.
- Update `/review` pass guidance so GitHub-backed work routes to `/github:post-review` and `/github:sync-review` before merge/archive.
- Update `/archive` guidance to require PR or merge evidence for GitHub-backed changes.
- Keep explicit local-only bypass support with documented human acceptance and residual risk.
- Add OpenSpec change artifacts and scenario tests for the workflow handoff behavior.

## Verification

- `openspec validate strengthen-github-workflow-handoffs`
- `openspec validate --specs`
- `openspec validate --changes`
- Search active skill/schema guidance for direct GitHub-backed `/review` pass -> `/archive` bypasses.

## OpenSpec

- `openspec/changes/strengthen-github-workflow-handoffs`
- `openspec/specs/github-workflow/spec.md`
- `openspec/specs/github-orchestration-skills/spec.md`

## Residual Risk

- GitHub-backed versus explicit local-only detection is still instruction-driven, not automated enforcement.
- `/github:create-pr` still needs the follow-up improvement in #1 to auto-create a branch when starting on `main`.

## Links

- Issue: https://github.com/haipd91/WorkLoop/issues/2