### PR TITLE
Add AI-native human approval gates

### DIFF
--- a/.codex/skills/apply/SKILL.md
+++ b/.codex/skills/apply/SKILL.md
@@ -50,7 +50,10 @@ Apply tasks from an OpenSpec change.
    - If `state: "blocked"` (missing artifacts): show the missing artifacts and stop. Suggest the exact previous workflow step instead:
      - missing proposal/specs/design/tasks -> run `/propose <name>` or `/design <name>` as appropriate
      - missing tests -> run `/tdd <name>` or get explicit human approval to skip test generation for this change
-   - If `state: "all_done"`: confirm implementation is complete. For GitHub-backed changes, suggest `/github:create-pr <name>` before `/review`. For explicit local-only changes, suggest `/review <name>` and record that GitHub issue/PR evidence was intentionally skipped.
+   - If `state: "all_done"`: confirm implementation is complete, then choose the next handoff:
+     - GitHub-backed change -> suggest `/github:create-pr <name>`
+     - Local-only change with explicit accepted GitHub exception -> suggest `/review <name>`
+     - If unclear whether GitHub applies -> ask before suggesting a next command
    - Otherwise: proceed to implementation
 
 4. **Read context files**
@@ -91,8 +94,12 @@ Apply tasks from an OpenSpec change.
    Display:
    - Tasks completed this session
    - Overall progress: "N/M tasks complete"
-   - If all done: for GitHub-backed changes, suggest `/github:create-pr <name>` before `/review`; for explicit local-only changes, suggest `/review <name>` and record the accepted GitHub evidence bypass.
+   - If all done: suggest the correct next command:
+     - `/github:create-pr <name>` for GitHub-backed changes
+     - `/review <name>` only for local-only changes with explicit accepted GitHub exception
    - If paused: explain why and wait for guidance
+
+   Treat a change as GitHub-backed when any context artifact contains a GitHub issue/PR URL, an explicit linked issue, or specs/docs requiring the GitHub-backed workflow. Do not blindly repeat the generic OpenSpec CLI instruction if it conflicts with the GitHub-backed handoff order.
 
 **Output During Implementation**
 
@@ -122,9 +129,9 @@ Working on task 4/7: <task description>
 - [x] Task 2
 ...
 
-All tasks complete. For GitHub-backed changes, run `/github:create-pr <change-name>` before `/review <change-name>`.
+All tasks complete. Run `/github:create-pr <change-name>` next for GitHub-backed changes.
 
-If the human explicitly accepted local-only work, run `/review <change-name>` and record that GitHub issue/PR evidence was intentionally skipped.
+For local-only changes with explicit accepted GitHub exception, run `/review <change-name>` before archive.
 ```
 
 **Output On Pause (Issue Encountered)**

--- a/.codex/skills/archive/SKILL.md
+++ b/.codex/skills/archive/SKILL.md
@@ -81,6 +81,8 @@ Archive a completed change in the experimental workflow.
    blocking_findings: none
    reviewed_ref: <git HEAD>
    reviewed_diff: <sha256 fingerprint>
+   reviewed_implementation_diff: <sha256 implementation fingerprint>
+   reviewed_paths_excluded: openspec/changes/<name>/review.md
    reviewed_at: <ISO-8601 timestamp>
    ```
 
@@ -89,11 +91,14 @@ Archive a completed change in the experimental workflow.
    - `blocking_findings`
    - `reviewed_ref`
    - `reviewed_diff`
+   - `reviewed_implementation_diff`
+   - `reviewed_paths_excluded`
    - `reviewed_at`
 
    Accepted values:
    - `verdict`: only `pass` allows archive
    - `blocking_findings`: only `none` allows archive
+   - `reviewed_paths_excluded`: exactly `openspec/changes/<name>/review.md`
 
    **Block archive when:**
    - required metadata is missing
@@ -106,9 +111,14 @@ Archive a completed change in the experimental workflow.
    ```bash
    git rev-parse HEAD
    (git diff --binary && git diff --cached --binary) | shasum -a 256
+   (git diff --binary -- . ':(exclude)openspec/changes/<name>/review.md' && git diff --cached --binary -- . ':(exclude)openspec/changes/<name>/review.md') | shasum -a 256
    ```
 
-   If current ref/diff differs from `reviewed_ref` or `reviewed_diff`, block archive and tell the user to rerun `/review <name>`.
+   Use `reviewed_ref` and `reviewed_diff` for traceability and legacy diagnostics. The stale gate MUST compare the current implementation fingerprint against `reviewed_implementation_diff`, excluding only the path in `reviewed_paths_excluded`.
+
+   If the implementation fingerprint matches, continue even when `HEAD` differs from `reviewed_ref` because the only post-review change is `openspec/changes/<name>/review.md`.
+
+   If the implementation fingerprint differs, block archive and tell the user to rerun `/review <name>`.
 
    Before proceeding, show:
    - review verdict

--- a/.codex/skills/github-merge/SKILL.md
+++ b/.codex/skills/github-merge/SKILL.md
@@ -34,12 +34,18 @@ Before merge, verify:
 
 - PR target is clear.
 - Linked issue is known or missing linkage is explicitly accepted by the human.
+- If the PR is draft and every other gate passes, mark it ready for review through GitHub MCP/plugin before merging.
 - PR has no unresolved blocking comments or requested changes.
-- Required checks/CI are passing, skipped, or explicitly bypassed by the human.
+- Required checks/CI are passing or skipped.
+- If GitHub exposes no required checks or statuses for the PR head commit, treat checks as N/A and record that state instead of blocking.
+- Failing or pending required checks block unless the human explicitly accepts a documented bypass.
+- GitHub reviewer approval is required only when branch protection or explicit repository policy requires it.
+- Human release approval is required before merge unless that approval was already provided in the merge request.
 - `openspec/changes/<change-name>/review.md` exists.
 - `review.md` has:
   - `verdict: pass`
   - `blocking_findings: none`
+  - non-stale implementation-state metadata, allowing review-artifact-only commits after review
 - OpenSpec change path is known for archive handoff.
 
 ## Workflow
@@ -47,10 +53,14 @@ Before merge, verify:
 1. Resolve PR, repository, linked issue, and OpenSpec change.
 2. Read PR review/comment/check state through GitHub MCP/plugin.
 3. Read local `review.md` metadata.
-4. If any gate fails, block and return handoff.
-5. Merge the PR through GitHub MCP/plugin.
-6. Close the linked issue if GitHub did not auto-close it and closing is appropriate.
-7. Return the handoff to `/archive <change-name>`.
+4. Classify checks as passing, blocked, bypassed, or N/A.
+5. If GitHub reviewer approval is required by branch protection or repository policy and missing, block and return handoff.
+6. If any other gate fails, block and return handoff.
+7. If the PR is draft, mark it ready for review through GitHub MCP/plugin.
+8. Confirm explicit human release approval unless already provided in the merge request.
+9. Merge the PR through GitHub MCP/plugin.
+10. Close the linked issue if GitHub did not auto-close it and closing is appropriate.
+11. Return the handoff to `/archive <change-name>`.
 
 ## Handoff
 
@@ -79,8 +89,16 @@ Block instead of merging when:
 
 - PR target is unclear
 - GitHub MCP/plugin is unavailable
-- required checks are failing or unreadable without accepted bypass
+- required checks are failing or pending without accepted documented bypass
+- GitHub reviewer approval is required by branch protection or repository policy and missing
+- human release approval is missing
 - unresolved blocking comments remain
 - requested changes remain
 - local `review.md` is missing, malformed, stale, or failing
 - issue close behavior is unclear and cannot be safely inferred
+
+Do not block solely because:
+
+- the PR is draft after all gates pass; mark it ready instead
+- GitHub exposes no required checks or statuses; record checks as N/A
+- no GitHub approval review exists when branch protection and repo policy do not require one

--- a/.codex/skills/github-sync-review/SKILL.md
+++ b/.codex/skills/github-sync-review/SKILL.md
@@ -44,6 +44,8 @@ If PR target is unclear, ask for the PR.
    - approvals
    - resolved/outdated state when available
 4. Read CI/check state when exposed by GitHub MCP/plugin.
+   - If no required checks or statuses are exposed for the PR head commit, classify checks as N/A instead of a blocker.
+   - If required checks are failing or pending, classify them as CI/check blockers.
 5. Classify feedback:
    - blocking actionable
    - non-blocking actionable
@@ -51,6 +53,7 @@ If PR target is unclear, ask for the PR.
    - ambiguous
    - already resolved or outdated
    - CI/check blocker
+   - checks N/A
 6. Produce an action plan.
 7. Return the handoff.
 

--- a/.codex/skills/review/SKILL.md
+++ b/.codex/skills/review/SKILL.md
@@ -58,13 +58,16 @@ git diff --cached
 
 Use the diff to compare implementation against proposal, specs, design, tasks, and tests.
 
-Create a deterministic review fingerprint:
+Create deterministic review fingerprints.
 
 ```bash
 (git diff --binary && git diff --cached --binary) | shasum -a 256
+(git diff --binary -- . ':(exclude)openspec/changes/<name>/review.md' && git diff --cached --binary -- . ':(exclude)openspec/changes/<name>/review.md') | shasum -a 256
 ```
 
-The fingerprint command must still run for an empty diff; empty review state is still a concrete SHA-256 value.
+Use the first fingerprint as the legacy full diff fingerprint. Use the second fingerprint as the reviewed implementation fingerprint. The implementation fingerprint must exclude only `openspec/changes/<name>/review.md`, so committing or editing the review artifact after review does not make the reviewed implementation stale.
+
+The fingerprint commands must still run for an empty diff; empty review state is still a concrete SHA-256 value.
 
 ### 3. Review Stance
 
@@ -94,6 +97,8 @@ verdict: pass
 blocking_findings: none
 reviewed_ref: <git HEAD>
 reviewed_diff: <sha256 fingerprint>
+reviewed_implementation_diff: <sha256 implementation fingerprint>
+reviewed_paths_excluded: openspec/changes/<name>/review.md
 reviewed_at: <ISO-8601 timestamp>
 ```
 
@@ -101,6 +106,7 @@ Allowed values:
 
 - `verdict`: `pass` or `fail`
 - `blocking_findings`: `none` or `present`
+- `reviewed_paths_excluded`: exactly `openspec/changes/<name>/review.md`
 
 Required sections:
 
@@ -145,6 +151,7 @@ After writing `review.md`, summarize:
 - tests/checks run
 - residual risk
 - reviewed ref/diff state
+- reviewed implementation diff and excluded path
 
 If verdict is pass, say:
 

--- a/docs/ai-native-codex-workflow.md
+++ b/docs/ai-native-codex-workflow.md
@@ -199,6 +199,8 @@ review.md -> /archive
     - `blocking_findings: none|present`
     - `reviewed_ref`
     - `reviewed_diff`
+    - `reviewed_implementation_diff`
+    - `reviewed_paths_excluded: openspec/changes/<name>/review.md`
     - `reviewed_at`
   - sections:
     - Findings
@@ -210,6 +212,7 @@ review.md -> /archive
   - `openspec status` chỉ coi `review: done` là `review.md` tồn tại, không phải verdict pass
   - blocking findings => `verdict: fail`
   - skipped tests/missing artifacts phải ghi vào residual risk
+  - stale review check dựa trên implementation fingerprint, exclude đúng `review.md`, không chỉ dựa vào `HEAD == reviewed_ref`
   - review evidence phải durable, không chỉ nằm trong chat.
 
 ### 4.8 `/archive`
@@ -227,7 +230,8 @@ review.md -> /archive
   - move change vào `openspec/changes/archive/YYYY-MM-DD-<name>/`
 - Gate:
   - nếu còn incomplete artifact/task, phải cảnh báo và human confirm.
-  - nếu `review` artifact thiếu/chưa done, thiếu `review.md`, review malformed, stale, verdict không pass, hoặc còn blocking findings thì phải block.
+  - nếu `review` artifact thiếu/chưa done, thiếu `review.md`, review malformed, implementation stale, verdict không pass, hoặc còn blocking findings thì phải block.
+  - commit chỉ thêm/sửa `review.md` sau review không làm stale implementation state.
   - trước khi archive, phải hiện review verdict và residual risk để human accept risk.
 
 ## 5. Specialist Agent Model Cho `/design`
@@ -389,6 +393,7 @@ Một change chỉ được xem là xong khi:
 - Sửa ngoài scope rồi biện minh là cleanup.
 - Đi thẳng từ `/apply` sang `/archive` mà không chạy `/review`.
 - Archive khi `review.md` thiếu, fail, stale, malformed, hoặc còn blocking findings.
+- Coi commit `review.md` là stale implementation change.
 - Archive change khi còn open question chưa được human accept.
 
 ## 10. Ví dụ thực tế

--- a/docs/github-orchestration-workflow.md
+++ b/docs/github-orchestration-workflow.md
@@ -119,6 +119,14 @@ Rule:
   - next command
 - Block nếu thiếu issue link hoặc OpenSpec path mà human chưa chấp nhận.
 
+### 6.2.1 `/apply` handoff for GitHub-backed changes
+
+- Khi apply tasks complete cho change có GitHub issue/PR context:
+  - next command phải là `/github:create-pr <change-name>`
+  - không handoff thẳng sang `/review`
+- `/review` chạy sau khi PR đã tồn tại, để review artifact có thể được post/sync vào GitHub source of truth.
+- Local-only exception chỉ dùng `/review` sau `/apply` khi human đã accept rõ việc bỏ qua GitHub issue/PR tracking.
+
 ### 6.3 `/github:post-review`
 
 - Input: PR target + `openspec/changes/<change>/review.md`.
@@ -159,10 +167,15 @@ Rule:
 - Gates:
   - PR review state OK
   - no unresolved blocking comments
-  - checks pass hoặc human accepted bypass
+  - required checks pass hoặc human accepted documented bypass
+  - no required checks/statuses exposed => checks N/A, không block
+  - draft PR ready gates pass => Codex mark ready, không bắt human click
+  - GitHub reviewer approval chỉ bắt buộc khi branch protection/repo policy yêu cầu
+  - human release approval explicit trước merge
   - `review.md` exists
   - `verdict: pass`
   - `blocking_findings: none`
+  - review implementation-state metadata không stale; commit chỉ thêm/sửa `review.md` không block
   - issue linkage known hoặc accepted missing
 - Output:
   - merged PR
@@ -234,7 +247,7 @@ Blocked state vẫn phải có handoff. Không được kết thúc bằng trạ
 
 - Current state: PR merged and issue closed.
 - Done: Merged PR #45 and closed issue #123.
-- Needs human: Confirm archive.
+- Needs human: Run archive when ready.
 - Next command: `/archive issue-123-add-github-orchestration`
 - Blockers: none
 - Links: https://github.com/org/repo/pull/45, https://github.com/org/repo/issues/123

--- a/openspec/changes/ai-native-human-approval-gates/.openspec.yaml
+++ b/openspec/changes/ai-native-human-approval-gates/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-custom
+created: 2026-05-03

--- a/openspec/changes/ai-native-human-approval-gates/design.md
+++ b/openspec/changes/ai-native-human-approval-gates/design.md
@@ -1,0 +1,72 @@
+## Context
+
+The current workflow caught an important failure mode on PR #3: after `/review` created `review.md`, committing that artifact changed HEAD and made `reviewed_ref` stale. This is not an implementation change, but the current gate treats it like one.
+
+The larger problem is workflow ownership. Codex should operate mechanical steps end-to-end. The human should approve material release risk, not manually interpret draft state, approval state, check absence, or artifact commit semantics.
+
+Issue: https://github.com/haipd91/WorkLoop/issues/4
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make review metadata describe reviewed implementation state, not merely current HEAD.
+- Allow review-artifact-only commits after review without stale gate failure.
+- Let `/github:merge` mark PRs ready when gates pass.
+- Separate GitHub reviewer approval from human release approval.
+- Treat absent checks as N/A when no required checks are configured or exposed.
+- Require human release approval for merge, then let Codex perform merge/archive steps.
+
+**Non-Goals:**
+
+- Bypass required branch protection.
+- Hide failing CI.
+- Remove review artifact metadata validation.
+- Replace GitHub PR review with chat approval when branch protection requires GitHub reviewer approval.
+
+## Decisions
+
+### Decision: Review tracks implementation state
+
+`review.md` should track implementation state through metadata that excludes the review artifact itself. Existing `reviewed_ref` can remain for traceability, but stale checks must compare current implementation state against the reviewed implementation state.
+
+Alternative considered: never commit `review.md` before merge/archive. Rejected because the GitHub source-of-truth workflow expects committed OpenSpec artifacts.
+
+### Decision: Review artifact commits are allowed
+
+If the only post-review change is `openspec/changes/<name>/review.md`, merge/archive should not fail stale review. Any non-review file change still requires rerunning `/review`.
+
+Alternative considered: automatically rerun review after committing `review.md`. Rejected because it creates a loop unless metadata semantics change anyway.
+
+### Decision: AI owns mechanical PR readiness
+
+If PR gates pass and the PR is draft, `/github:merge` should mark it ready before merging. The human should not need to click “Ready for review.”
+
+Alternative considered: block on draft PR. Rejected because draft state is mechanical once gates pass.
+
+### Decision: Human release approval is separate from GitHub approval
+
+GitHub approval is required only when branch protection or explicit repo policy requires it. Otherwise, human approval in the merge request can satisfy release/risk approval.
+
+Alternative considered: always require GitHub approval. Rejected because single-owner repos may not have reviewer policy and self-approval is weak.
+
+## Risks / Trade-offs
+
+- [Risk] A meaningful implementation change is misclassified as review-only -> Mitigation: compare pathsets and fingerprints excluding only `openspec/changes/<name>/review.md`.
+- [Risk] Missing checks hide CI failures -> Mitigation: distinguish no checks exposed from failing/pending required checks.
+- [Risk] Human approval in chat is not durable -> Mitigation: merge/PR comments should record approval when feasible.
+- [Risk] Branch protection rules are not fully exposed -> Mitigation: block if GitHub rejects merge or required protection cannot be determined safely.
+
+## Migration Plan
+
+1. Update review artifact metadata contract.
+2. Update `/review`, `/archive`, and `/github:merge` guidance.
+3. Update `/github:sync-review` wording for no-checks/N/A state if needed.
+4. Add tests covering review-artifact-only commits, draft readiness, approvals, and check states.
+
+Rollback: revert guidance/spec updates. Existing fail-closed review gate remains available.
+
+## Resolved Questions
+
+- Metadata names: keep `reviewed_ref` and `reviewed_diff` for traceability, add `reviewed_implementation_diff` and `reviewed_paths_excluded`.
+- Human release approval durability: prefer a PR comment when the GitHub connector supports it; otherwise record the approval in the merge handoff with residual risk.

--- a/openspec/changes/ai-native-human-approval-gates/proposal.md
+++ b/openspec/changes/ai-native-human-approval-gates/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+The GitHub-backed workflow still makes the human operate mechanical gates such as draft readiness, approval interpretation, review artifact commits, merge readiness, and archive handoff. It also has a stale-review loop: committing `review.md` changes HEAD and can invalidate the review metadata even when implementation state is unchanged.
+
+## What Changes
+
+- Define an AI-native workflow where Codex runs operational steps and the human approves only material risk or release decisions.
+- Update review metadata semantics so committing `review.md` does not invalidate the reviewed implementation state.
+- Define when draft PRs can be marked ready automatically.
+- Clarify GitHub approval versus human release approval.
+- Treat missing CI/check data as N/A when no required checks are configured or exposed.
+- Update merge/archive gate behavior to block only on meaningful safety failures.
+
+## Capabilities
+
+### New Capabilities
+
+### Modified Capabilities
+
+- `github-workflow`: Human approval boundary and AI-native delivery ownership.
+- `github-orchestration-skills`: `/github:merge` readiness, draft, approval, and check semantics.
+- `review-quality-gate`: Review artifact metadata and stale-review semantics.
+
+## Impact
+
+- Affected skill instructions: `.codex/skills/review/SKILL.md`, `.codex/skills/archive/SKILL.md`, `.codex/skills/github-merge/SKILL.md`, and possibly `.codex/skills/github-sync-review/SKILL.md`.
+- Affected specs: `github-workflow`, `github-orchestration-skills`, `review-quality-gate`.
+- No new external dependency expected.

--- a/openspec/changes/ai-native-human-approval-gates/review.md
+++ b/openspec/changes/ai-native-human-approval-gates/review.md
@@ -1,0 +1,40 @@
+verdict: pass
+blocking_findings: none
+reviewed_ref: 56b5cefc84457738c81c8e7155cd2340bc027717
+reviewed_diff: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+reviewed_implementation_diff: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+reviewed_paths_excluded: openspec/changes/ai-native-human-approval-gates/review.md
+reviewed_at: 2026-05-03T15:44:28Z
+
+## Findings
+
+No blocking findings found.
+
+Reviewed the committed PR diff against the approved proposal, design, specs, tasks, and scenario tests. The implementation matches the intended workflow changes:
+
+- `/review` and `/archive` now record and validate implementation-state metadata separately from review artifact commits.
+- `/github:merge` now separates draft readiness, GitHub reviewer approval, human release approval, and checks N/A handling.
+- `/github:sync-review` now classifies missing required checks/statuses as N/A instead of a blocker.
+- `/apply` now routes GitHub-backed changes to `/github:create-pr` before `/review`.
+- Workflow docs and OpenSpec scenarios cover the new handoff order and review-artifact-only commit behavior.
+
+## Tests Run
+
+- `openspec validate ai-native-human-approval-gates --strict`
+- `git diff --check HEAD~1..HEAD`
+- Manual review of `git diff origin/main...HEAD` against:
+  - `openspec/changes/ai-native-human-approval-gates/proposal.md`
+  - `openspec/changes/ai-native-human-approval-gates/design.md`
+  - `openspec/changes/ai-native-human-approval-gates/specs/**/*.md`
+  - `openspec/changes/ai-native-human-approval-gates/tasks.md`
+  - `openspec/changes/ai-native-human-approval-gates/tests/*.md`
+
+## Residual Risk
+
+- This change updates workflow instructions and documentation, not executable enforcement. Future runs still depend on agents following the updated skill text.
+- The GitHub-backed PR exists as draft PR #5 and this review artifact still needs to be posted with `/github:post-review 5` before review sync and merge.
+- An unrelated untracked change exists at `openspec/changes/issue-1-improve-create-pr-branch-flow/`; it was ignored for this review and is not part of PR #5.
+
+## Verdict
+
+Pass. The implementation satisfies the approved artifacts, all tasks are complete, required scenario coverage exists, and no blocking workflow-gate issue was found.

--- a/openspec/changes/ai-native-human-approval-gates/specs/github-orchestration-skills/spec.md
+++ b/openspec/changes/ai-native-human-approval-gates/specs/github-orchestration-skills/spec.md
@@ -1,0 +1,44 @@
+## MODIFIED Requirements
+
+### Requirement: End-to-end GitHub handoff order
+WorkLoop SHALL document and enforce the expected GitHub-backed handoff sequence around OpenSpec work while keeping mechanical operations AI-native.
+
+#### Scenario: Standard GitHub-backed workflow
+- **WHEN** a tracked WorkLoop change moves from discovery to archive
+- **THEN** the workflow MUST route through `/explore`, `/github:create-issue`, `/brief` or `/propose`, `/tdd`, `/apply`, `/github:create-pr`, `/review`, `/github:post-review`, `/github:sync-review`, `/github:address-comments` when needed, `/github:merge`, and `/archive`
+
+#### Scenario: Apply completes for a GitHub-backed change
+- **WHEN** `/apply` completes all tasks for a change with GitHub issue, PR, or GitHub-backed workflow context
+- **THEN** the next handoff MUST be `/github:create-pr <change-name>` instead of `/review <change-name>`
+
+#### Scenario: Apply completes for a local-only change
+- **WHEN** `/apply` completes all tasks for a change with an explicitly accepted local-only exception
+- **THEN** the next handoff MAY be `/review <change-name>` before archive
+
+#### Scenario: Review feedback is clean
+- **WHEN** `/github:sync-review` finds no unresolved comments, requested changes, or failing required checks
+- **THEN** the next handoff MUST be `/github:merge`
+
+#### Scenario: Review feedback requires changes
+- **WHEN** `/github:sync-review` finds actionable unresolved feedback
+- **THEN** the next handoff MUST be `/github:address-comments` before merge
+
+#### Scenario: Draft PR is ready
+- **WHEN** `/github:merge` finds that a draft PR satisfies review, comment, check, issue, and local review gates
+- **THEN** it MUST mark the PR ready for review before merging instead of blocking for manual draft handling
+
+#### Scenario: GitHub reviewer approval is not required
+- **WHEN** branch protection or repository policy does not require GitHub reviewer approval
+- **THEN** `/github:merge` MUST NOT block only because no GitHub approval review exists
+
+#### Scenario: Human release approval is required
+- **WHEN** `/github:merge` is ready to merge a GitHub-backed change
+- **THEN** it MUST require explicit human release approval unless that approval was already provided in the merge request
+
+#### Scenario: CI is not configured
+- **WHEN** GitHub exposes no required checks or statuses for the PR head commit
+- **THEN** `/github:merge` MUST treat checks as not applicable and record that state instead of blocking as unreadable CI
+
+#### Scenario: Required CI fails
+- **WHEN** GitHub exposes required checks or statuses and any required check is failing or pending
+- **THEN** `/github:merge` MUST block until checks pass or the human explicitly accepts a documented bypass

--- a/openspec/changes/ai-native-human-approval-gates/specs/github-workflow/spec.md
+++ b/openspec/changes/ai-native-human-approval-gates/specs/github-workflow/spec.md
@@ -1,0 +1,24 @@
+## MODIFIED Requirements
+
+### Requirement: Quality gates
+WorkLoop SHALL define quality gates before PR readiness, merge, and OpenSpec archive, with Codex owning operational execution and the human owning final material risk or release approval.
+
+#### Scenario: PR readiness gate
+- **WHEN** a PR is marked ready for review
+- **THEN** the workflow MUST verify that scope, requirements, implementation plan, and verification evidence are represented in GitHub or committed OpenSpec artifacts
+
+#### Scenario: Archive gate
+- **WHEN** an OpenSpec change is archived after delivery
+- **THEN** the workflow MUST verify that review requirements are satisfied and that the GitHub PR or merge record provides durable delivery evidence
+
+#### Scenario: Local-only exception
+- **WHEN** a change intentionally skips GitHub issue or PR tracking
+- **THEN** the workflow MUST record explicit human acceptance and residual risk before review or archive treats the missing GitHub evidence as non-blocking
+
+#### Scenario: Human approves release risk
+- **WHEN** Codex has completed issue, PR, review, sync, and merge gate checks for a GitHub-backed change
+- **THEN** the human approval needed to proceed MUST be limited to material risk or release acceptance unless GitHub branch protection requires a separate reviewer approval
+
+#### Scenario: Codex owns mechanical workflow steps
+- **WHEN** a workflow step is mechanical and all required gates are satisfied
+- **THEN** Codex MUST perform that step without asking the human to operate GitHub or OpenSpec manually

--- a/openspec/changes/ai-native-human-approval-gates/specs/review-quality-gate/spec.md
+++ b/openspec/changes/ai-native-human-approval-gates/specs/review-quality-gate/spec.md
@@ -1,0 +1,29 @@
+## MODIFIED Requirements
+
+### Requirement: Define parseable review artifact contract
+The review artifact SHALL include deterministic machine-checkable metadata for the reviewed implementation state and required human-readable sections.
+
+#### Scenario: Review artifact is valid
+- **WHEN** `/review` writes `openspec/changes/<name>/review.md`
+- **THEN** the artifact includes `verdict`, `blocking_findings`, `reviewed_ref`, `reviewed_diff`, `reviewed_implementation_diff`, `reviewed_paths_excluded`, and `reviewed_at` metadata
+- **THEN** `reviewed_paths_excluded` MUST be exactly `openspec/changes/<name>/review.md`
+- **THEN** the artifact includes Findings, Tests Run, Residual Risk, and Verdict sections
+
+#### Scenario: Review artifact is malformed
+- **WHEN** archive starts and `review.md` is missing required metadata, has duplicate or contradictory metadata, or uses unknown values
+- **THEN** archive is blocked with the malformed review condition as the reason
+
+### Requirement: Block archive on stale review
+Archive SHALL be blocked when the implementation state differs from the implementation state recorded in the review artifact, but SHALL NOT treat review-artifact-only commits as stale implementation changes.
+
+#### Scenario: Review matches current implementation state
+- **WHEN** archive starts and the current implementation state matches the implementation state recorded in `review.md`
+- **THEN** archive may continue to the remaining archive checks even if `review.md` was committed after the reviewed implementation ref
+
+#### Scenario: Review artifact commit only
+- **WHEN** the only change after `reviewed_ref` is adding or updating `openspec/changes/<name>/review.md`
+- **THEN** archive and merge gates MUST NOT block as stale solely because HEAD differs from `reviewed_ref`
+
+#### Scenario: Review is stale
+- **WHEN** archive starts and non-review implementation files differ from the implementation state recorded in `review.md`
+- **THEN** archive is blocked with instructions to rerun `/review`

--- a/openspec/changes/ai-native-human-approval-gates/tasks.md
+++ b/openspec/changes/ai-native-human-approval-gates/tasks.md
@@ -1,0 +1,20 @@
+## 1. Review Metadata Semantics
+
+- [x] 1.1 Update `review-quality-gate` spec to define implementation-state metadata that can exclude `review.md`.
+- [x] 1.2 Update `/review` guidance to write implementation-state metadata and residual risk.
+- [x] 1.3 Update `/archive` guidance to allow review-artifact-only commits without stale failure.
+
+## 2. AI-Native Merge Gates
+
+- [x] 2.1 Update `github-workflow` spec to define Codex-owned mechanical steps and human release approval.
+- [x] 2.2 Update `github-orchestration-skills` spec for draft PR readiness, approval semantics, and N/A checks.
+- [x] 2.3 Update `/github:merge` guidance to mark draft PRs ready when gates pass.
+- [x] 2.4 Update `/github:merge` guidance to require GitHub reviewer approval only when branch protection or repo policy requires it.
+- [x] 2.5 Update `/github:merge` guidance to treat missing checks as N/A when no required checks are configured or exposed.
+- [x] 2.6 Update `/apply` handoff so GitHub-backed changes route to `/github:create-pr` before `/review`.
+
+## 3. Verification
+
+- [x] 3.1 Generate test scenarios with `/tdd ai-native-human-approval-gates`.
+- [x] 3.2 Run OpenSpec validation for `ai-native-human-approval-gates`.
+- [x] 3.3 Verify scenarios cover review-artifact-only commits, draft PR readiness, human approval, GitHub approval, and check states.

--- a/openspec/changes/ai-native-human-approval-gates/tests/1-review-metadata-semantics.md
+++ b/openspec/changes/ai-native-human-approval-gates/tests/1-review-metadata-semantics.md
@@ -1,0 +1,49 @@
+# Test Scenario: 1 review-metadata-semantics
+
+- Source task: 1.1 Update `review-quality-gate` spec to define implementation-state metadata that can exclude `review.md`.
+- Source task: 1.2 Update `/review` guidance to write implementation-state metadata and residual risk.
+- Source task: 1.3 Update `/archive` guidance to allow review-artifact-only commits without stale failure.
+- Related requirements:
+  - `review-quality-gate`: Define parseable review artifact contract.
+  - `review-quality-gate`: Block archive on stale review.
+- Assumptions:
+  - `review.md` remains a committed OpenSpec artifact.
+  - Review metadata must identify reviewed implementation state separately from the current repository HEAD.
+  - Only `openspec/changes/<name>/review.md` may be excluded from stale implementation checks.
+
+## Happy Path
+
+- Khi `/review` tạo `openspec/changes/<name>/review.md`
+- Thì artifact có metadata parseable: `verdict`, `blocking_findings`, `reviewed_ref`, `reviewed_diff`, `reviewed_implementation_diff`, `reviewed_paths_excluded`, và `reviewed_at`.
+- Thì `reviewed_paths_excluded` đúng bằng `openspec/changes/<name>/review.md`.
+- Thì artifact có các section: Findings, Tests Run, Residual Risk, Verdict.
+- Khi `review.md` được commit sau review và không có file implementation nào đổi thêm
+- Thì `/archive` và `/github:merge` không block vì `HEAD` khác `reviewed_ref`.
+
+## Edge Cases
+
+- `review.md` được thêm mới sau review, nhưng không có file khác đổi.
+- `review.md` được chỉnh lại nội dung residual risk hoặc metadata formatting, nhưng implementation-state metadata vẫn hợp lệ và implementation files không đổi.
+- `reviewed_ref` khác `HEAD`, nhưng pathset sau review chỉ chứa `openspec/changes/<name>/review.md`.
+- `review.md` chứa verdict hợp lệ nhưng có residual risk cần human release approval; archive vẫn đọc được risk thay vì coi artifact malformed.
+
+## Error Cases
+
+- `review.md` thiếu implementation-state metadata.
+- `review.md` có metadata trùng lặp hoặc mâu thuẫn, ví dụ hai verdict khác nhau.
+- `review.md` dùng giá trị metadata không xác định.
+- Sau review có thay đổi ở file ngoài `openspec/changes/<name>/review.md`.
+- Path loại trừ quá rộng, ví dụ loại trừ cả thư mục `openspec/changes/<name>/`.
+
+## Expected Outcomes
+
+- Review artifact hợp lệ cho phép merge/archive tiếp tục khi chỉ có review-artifact-only commit.
+- Review artifact malformed block archive với lý do rõ ràng.
+- Non-review implementation changes sau review block merge/archive và yêu cầu chạy lại `/review`.
+- Stale check dựa trên implementation state, không dựa máy móc vào việc `HEAD == reviewed_ref`.
+
+## Notes for Implementation
+
+- Không dùng `reviewed_ref` đơn lẻ làm stale gate.
+- So sánh pathset/fingerprint và chỉ exclude đúng `openspec/changes/<name>/review.md`.
+- Hướng dẫn `/review` phải ghi residual risk đủ rõ để `/github:merge` có thể xin human release approval trên risk thật.

--- a/openspec/changes/ai-native-human-approval-gates/tests/2-ai-native-merge-gates.md
+++ b/openspec/changes/ai-native-human-approval-gates/tests/2-ai-native-merge-gates.md
@@ -1,0 +1,61 @@
+# Test Scenario: 2 ai-native-merge-gates
+
+- Source task: 2.1 Update `github-workflow` spec to define Codex-owned mechanical steps and human release approval.
+- Source task: 2.2 Update `github-orchestration-skills` spec for draft PR readiness, approval semantics, and N/A checks.
+- Source task: 2.3 Update `/github:merge` guidance to mark draft PRs ready when gates pass.
+- Source task: 2.4 Update `/github:merge` guidance to require GitHub reviewer approval only when branch protection or repo policy requires it.
+- Source task: 2.5 Update `/github:merge` guidance to treat missing checks as N/A when no required checks are configured or exposed.
+- Source task: 2.6 Update `/apply` handoff so GitHub-backed changes route to `/github:create-pr` before `/review`.
+- Related requirements:
+  - `github-workflow`: Quality gates.
+  - `github-orchestration-skills`: End-to-end GitHub handoff order.
+- Assumptions:
+  - Codex can inspect PR draft state, reviews, unresolved feedback, checks/statuses, issue link, and local review gate evidence.
+  - GitHub branch protection remains authoritative when it requires reviewer approval or checks.
+  - Human release approval is a material risk/release decision, not a request to click mechanical GitHub controls.
+
+## Happy Path
+
+- Khi `/github:merge` kiểm tra một draft PR và thấy review, comment, check, issue, và local review gates đều pass
+- Thì `/github:merge` mark PR ready for review trước khi merge thay vì block để human tự xử lý draft state.
+- Khi repo không yêu cầu GitHub reviewer approval qua branch protection hoặc policy rõ ràng
+- Thì `/github:merge` không block chỉ vì thiếu GitHub approval review.
+- Khi không có required checks hoặc statuses được GitHub expose cho PR head commit
+- Thì `/github:merge` ghi trạng thái checks là N/A và tiếp tục tới human release approval.
+- Khi mọi gate đã pass
+- Thì `/github:merge` chỉ hỏi human release approval cho material risk hoặc release acceptance, rồi Codex tự thực hiện merge/archive handoff.
+- Khi `/apply` hoàn tất một GitHub-backed change
+- Thì handoff tiếp theo là `/github:create-pr <change-name>`, không phải `/review <change-name>`.
+
+## Edge Cases
+
+- PR đã ready sẵn; `/github:merge` không cần đổi draft state nhưng vẫn kiểm tra đầy đủ gates.
+- PR có optional checks không required và không fail theo policy; `/github:merge` không coi đó là blocker bắt buộc.
+- Không đọc được branch protection đầy đủ, nhưng GitHub merge API sau đó reject vì required rule; `/github:merge` phải block và báo reason từ GitHub.
+- Human đã approval release ngay trong merge request hiện tại; `/github:merge` không hỏi lại cùng approval.
+- GitHub approval tồn tại nhưng có unresolved requested changes/comment threads; `/github:merge` vẫn route qua `/github:address-comments`.
+- Change được human accept là local-only; `/apply` có thể handoff sang `/review <change-name>`.
+
+## Error Cases
+
+- Required CI check fail hoặc pending.
+- Branch protection hoặc repo policy yêu cầu reviewer approval nhưng PR chưa có approval hợp lệ.
+- PR có unresolved actionable feedback hoặc requested changes.
+- Local review gate thiếu `review.md`, review artifact malformed, hoặc review stale do non-review implementation changes.
+- Human không approve release risk khi `/github:merge` hỏi.
+- `/apply` không xác định được change có GitHub-backed hay local-only; phải hỏi thay vì đoán handoff.
+
+## Expected Outcomes
+
+- Draft state không còn là blocker thủ công khi gates đã pass.
+- GitHub reviewer approval chỉ required khi branch protection hoặc repo policy required.
+- Missing checks được phân loại N/A khi không có required checks/statuses exposed, không bị gọi là unreadable CI.
+- Required failing/pending checks vẫn block trừ khi human explicit accept documented bypass.
+- Merge/archive chỉ diễn ra sau human release approval hoặc approval đã có trong request.
+- GitHub-backed workflow giữ đúng thứ tự `/apply` -> `/github:create-pr` -> `/review`.
+
+## Notes for Implementation
+
+- Tách ba khái niệm: GitHub reviewer approval, human release approval, và mechanical PR readiness.
+- Nếu phải bypass failing/pending checks, guidance phải yêu cầu documented human acceptance rõ ràng.
+- Khi Codex thực hiện mechanical step, output cần ghi gate nào pass, gate nào N/A, gate nào cần human approval.

--- a/openspec/changes/ai-native-human-approval-gates/tests/3-verification.md
+++ b/openspec/changes/ai-native-human-approval-gates/tests/3-verification.md
@@ -1,0 +1,46 @@
+# Test Scenario: 3 verification
+
+- Source task: 3.1 Generate test scenarios with `/tdd ai-native-human-approval-gates`.
+- Source task: 3.2 Run OpenSpec validation for `ai-native-human-approval-gates`.
+- Source task: 3.3 Verify scenarios cover review-artifact-only commits, draft PR readiness, human approval, GitHub approval, and check states.
+- Related requirements:
+  - `github-workflow`: Quality gates.
+  - `github-orchestration-skills`: End-to-end GitHub handoff order.
+  - `review-quality-gate`: Define parseable review artifact contract.
+  - `review-quality-gate`: Block archive on stale review.
+- Assumptions:
+  - `/tdd` creates scenario specs only because no test framework is detected.
+  - OpenSpec validation is run later by `/apply` or a human step, not by `/tdd`.
+
+## Happy Path
+
+- Khi `/tdd ai-native-human-approval-gates` hoàn tất
+- Thì `openspec/changes/ai-native-human-approval-gates/tests/` có scenario files covering review metadata, AI-native merge gates, và verification.
+- Khi OpenSpec validation chạy cho change
+- Thì proposal, design, tasks, specs, và test scenario intent nhất quán về gates và terminology.
+- Khi reviewer đọc test scenarios
+- Thì họ thấy coverage rõ cho review-artifact-only commits, draft PR readiness, human release approval, GitHub reviewer approval, N/A checks, và failing/pending checks.
+
+## Edge Cases
+
+- Một task có nhiều requirements liên quan; scenario gom theo capability thay vì tạo file quá nhỏ cho từng checkbox.
+- Một requirement xuất hiện trong nhiều specs; scenario ghi rõ related requirements để tránh bỏ sót cross-capability behavior.
+- Test scenario không runnable; summary phải nói rõ scenario mode được dùng vì không phát hiện framework.
+
+## Error Cases
+
+- Không có test file nào được tạo cho task verification.
+- Scenario thiếu một trong các coverage bắt buộc: review-artifact-only commits, draft PR readiness, human approval, GitHub approval, check states.
+- Scenario viết theo implementation internals thay vì observable workflow behavior.
+- `/tdd` tự chạy hoặc claim OpenSpec validation đã chạy, trái guardrail.
+
+## Expected Outcomes
+
+- Có đủ scenario files để `/apply` dùng làm behavioral context.
+- Verification task có tiêu chí kiểm tra rõ, không chỉ là checklist chung chung.
+- Người review có thể xác nhận nhanh rằng các gates chính đã được test-intent coverage.
+
+## Notes for Implementation
+
+- `/tdd` không chạy validation hoặc tests.
+- Sau khi test scenarios được duyệt, bước tiếp theo phù hợp là `/apply ai-native-human-approval-gates`.


### PR DESCRIPTION
## Problem

Refs #4.

The GitHub-backed workflow still had mechanical human gates after implementation: PR draft readiness, approval interpretation, missing-check handling, review artifact commits, and merge/archive handoff. `review.md` commits could also make review metadata appear stale even when implementation state did not change.

## Approach

- Add OpenSpec change artifacts under `openspec/changes/ai-native-human-approval-gates/`.
- Update `/review` and `/archive` guidance to track implementation-state metadata separately from review artifact commits.
- Update `/github:merge` and `/github:sync-review` guidance for draft readiness, GitHub approval vs human release approval, required checks, and checks N/A.
- Update `/apply` handoff so GitHub-backed changes route to `/github:create-pr` before `/review`.
- Update workflow docs to reflect the GitHub-backed order and review/archive semantics.

## Verification

- `openspec validate ai-native-human-approval-gates --strict`
- `git diff --check`
- Rebased branch on `origin/main`; GitHub compare reports branch ahead by 1 and behind by 0.

## OpenSpec

- `openspec/changes/ai-native-human-approval-gates/`
- Tasks complete: 12/12
- Scenario tests:
  - `tests/1-review-metadata-semantics.md`
  - `tests/2-ai-native-merge-gates.md`
  - `tests/3-verification.md`

## Residual Risk

- This is instruction/documentation behavior, not executable enforcement. Runtime behavior still depends on future agents following the updated skills and on connector capability for GitHub operations.
- Branch protection visibility may still be incomplete through connectors; `/github:merge` is instructed to block if GitHub rejects merge or required protection cannot be determined safely.

## Links

- Issue: #4
- OpenSpec change: `openspec/changes/ai-native-human-approval-gates/`