### PR TITLE
Improve create PR branch flow

### DIFF
--- a/.codex/skills/github-create-pr/SKILL.md
+++ b/.codex/skills/github-create-pr/SKILL.md
@@ -31,7 +31,7 @@ If issue link or OpenSpec change path cannot be identified, ask the human or blo
 
 ## Workflow
 
-1. Resolve local repository, current branch, and remote.
+1. Resolve local repository, current branch, default base branch, and remote.
 2. Resolve issue link:
    - from user input
    - from branch name
@@ -44,9 +44,30 @@ If issue link or OpenSpec change path cannot be identified, ask the human or blo
    - completed tasks
    - tests or verification evidence
    - residual risk
-5. Push branch only if the user requested publishing and the local git state is ready.
-6. Create or update a draft PR through GitHub MCP/plugin.
-7. Return the handoff.
+5. Resolve the PR head branch:
+   - If current branch is `main` or the default base branch, derive a branch name before staging or committing.
+   - Preferred format: `codex/issue-<number>-<short-change-slug>`.
+   - If no issue number exists but missing linkage was explicitly accepted, use `codex/<change-slug>`.
+   - If the derived branch already exists and points to the intended work, switch to it.
+   - If the derived branch exists but points to unrelated work, block instead of force-updating it.
+   - If current branch is a non-main work branch selected by the human, preserve it as the PR head branch unless it is unsafe to publish.
+6. Stage, commit, and push only when scope is clear:
+   - Stage only files that belong to the resolved OpenSpec change and requested implementation.
+   - Do not stage unrelated dirty or untracked files.
+   - Create an intentional commit after verification and residual risk are known.
+   - Push the PR head branch after the commit succeeds.
+7. Create or update a draft PR through GitHub MCP/plugin.
+8. Return the handoff.
+
+## Branch and Publish Rules
+
+- Starting from `main` or the default base branch is supported. It is not a blocker by itself.
+- Do not publish directly from `main` or the default base branch.
+- Create or switch to the safe `codex/` work branch before staging, committing, pushing, or creating the PR.
+- Preserve an existing non-main work branch when the human already selected it.
+- If branch safety is unclear, block with a handoff before any commit or push.
+- If unrelated changes exist and cannot be separated safely, block with a handoff.
+- If unrelated changes can be clearly separated, stage explicit paths only and mention ignored local changes in the handoff.
 
 ## PR Body Shape
 
@@ -109,4 +130,8 @@ Block instead of guessing when:
 - OpenSpec change path is missing
 - GitHub MCP/plugin is unavailable
 - branch cannot be published safely
+- current branch is `main` or the default base branch and a safe `codex/` branch cannot be created or selected
+- derived `codex/` branch exists but points to unrelated work
+- dirty worktree contains unrelated changes that cannot be separated safely
+- no scoped local changes are available to commit or PR body would misrepresent the work
 - PR body would omit verification or residual risk

--- a/openspec/changes/issue-1-improve-create-pr-branch-flow/.openspec.yaml
+++ b/openspec/changes/issue-1-improve-create-pr-branch-flow/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-custom
+created: 2026-05-03

--- a/openspec/changes/issue-1-improve-create-pr-branch-flow/design.md
+++ b/openspec/changes/issue-1-improve-create-pr-branch-flow/design.md
@@ -1,0 +1,66 @@
+## Context
+
+The current `/github:create-pr` skill assumes the user or agent already prepared a publishable branch. In practice, Codex often starts from `main` with local OpenSpec and skill changes. Blocking at that point creates manual work and weakens the new GitHub-backed handoff flow.
+
+Issue: https://github.com/haipd91/WorkLoop/issues/1
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make `main` a supported starting point for `/github:create-pr`.
+- Automatically create and switch to a `codex/` branch when needed.
+- Preserve a human-selected work branch.
+- Require safe commit and push conditions before PR creation.
+- Keep PR body requirements: issue link, OpenSpec path, problem, approach, verification, residual risk.
+
+**Non-Goals:**
+
+- Create a general-purpose git workflow manager.
+- Auto-resolve unrelated dirty worktree changes.
+- Change `/github:create-issue`, `/review`, `/github:merge`, or `/archive` behavior.
+
+## Decisions
+
+### Decision: `main` means create a branch, not block
+
+If current branch is `main` or the repository default base branch, `/github:create-pr` should derive a branch name from the issue and change name, then switch to it before staging or committing.
+
+Preferred branch format:
+
+```text
+codex/issue-<number>-<short-change-slug>
+```
+
+Alternative considered: keep blocking on `main`. Rejected because `main` is the expected pre-publish state.
+
+### Decision: Existing work branch wins
+
+If the human already switched to a non-main branch, `/github:create-pr` should use that branch unless it is unsafe to publish.
+
+Alternative considered: always create a new branch. Rejected because it would ignore human branch setup and may split work.
+
+### Decision: Commit and push only when scope is clear
+
+The skill may stage, commit, and push only after it can identify the OpenSpec change path, issue link, changed files, verification, and residual risk. If unrelated changes exist, it must block or require explicit human acceptance.
+
+Alternative considered: push whatever is dirty. Rejected because this can publish unrelated user work.
+
+## Risks / Trade-offs
+
+- [Risk] Branch name collision -> Mitigation: detect existing branch and use it when it points to the intended work, otherwise block.
+- [Risk] Unrelated dirty changes get committed -> Mitigation: inspect changed files and block when scope is unclear.
+- [Risk] Missing verification gets hidden in PR body -> Mitigation: block when verification or residual risk would be omitted.
+- [Risk] Issue linkage is missing -> Mitigation: block unless the human explicitly accepts missing linkage.
+
+## Migration Plan
+
+1. Update `/github:create-pr` instructions with branch selection, commit, push, and PR creation flow.
+2. Update `github-orchestration-skills` spec.
+3. Add test scenarios for starting on `main`, existing branch, unsafe dirty state, and missing issue/verification.
+4. Validate the change.
+
+## Resolved Questions
+
+- `/github:create-pr` creates or switches branch after resolving repository, issue linkage, OpenSpec path, and local scope, but before staging or committing.
+- Commit messages should be intentional and related to the issue/change; user-provided commit hints may be used when they do not omit issue/change context.

--- a/openspec/changes/issue-1-improve-create-pr-branch-flow/proposal.md
+++ b/openspec/changes/issue-1-improve-create-pr-branch-flow/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+`/github:create-pr` currently blocks when local work is on `main`, but that is the normal default state before Codex starts publishing work. The workflow should create and switch to a safe `codex/` branch automatically unless the human already selected a work branch.
+
+## What Changes
+
+- Teach `/github:create-pr` to create and switch to a `codex/<issue-or-change-slug>` branch when the current branch is `main` or the default base branch.
+- Preserve existing behavior when the human already switched to a non-main work branch.
+- Define safe staging, commit, push, and draft PR creation expectations for local changes.
+- Keep blockers for missing issue linkage, unclear repository context, unsafe branch publication, omitted verification, or omitted residual risk.
+
+## Capabilities
+
+### New Capabilities
+
+### Modified Capabilities
+
+- `github-orchestration-skills`: `/github:create-pr` branch creation, switch, commit, push, and PR creation requirements.
+
+## Impact
+
+- Affected skill instruction: `.codex/skills/github-create-pr/SKILL.md`.
+- Affected spec: `openspec/specs/github-orchestration-skills/spec.md`.
+- No runtime dependency or GitHub Actions change expected.

--- a/openspec/changes/issue-1-improve-create-pr-branch-flow/review.md
+++ b/openspec/changes/issue-1-improve-create-pr-branch-flow/review.md
@@ -1,0 +1,41 @@
+verdict: pass
+blocking_findings: none
+reviewed_ref: 923b37b0a0c4eda546ca38b498bd0406c0e77b09
+reviewed_diff: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+reviewed_implementation_diff: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+reviewed_paths_excluded: openspec/changes/issue-1-improve-create-pr-branch-flow/review.md
+reviewed_at: 2026-05-03T15:59:28Z
+
+## Findings
+
+No blocking findings found.
+
+Reviewed the committed PR diff against the approved proposal, design, delta spec, tasks, and scenario tests. The implementation matches the requested workflow behavior:
+
+- `/github:create-pr` now treats `main` or the default base branch as a supported starting point.
+- The skill requires creating or switching to a safe `codex/` branch before staging, committing, pushing, or creating a PR.
+- Existing non-main work branches are preserved when selected by the human and safe to publish.
+- Scoped staging, intentional commit, push, draft PR create/update, and blocker guidance are documented.
+- Blockers remain for missing issue linkage, unclear scope, unsafe branch publication, missing verification, and missing residual risk.
+
+## Tests Run
+
+- `openspec validate issue-1-improve-create-pr-branch-flow --strict`
+- `git diff --check HEAD~1..HEAD`
+- `rg -n 'block.*main|main.*block|Starting from `main`|default base branch|safe `codex/` branch' .codex/skills/github-create-pr/SKILL.md`
+- Manual review of `git diff origin/main...HEAD` against:
+  - `openspec/changes/issue-1-improve-create-pr-branch-flow/proposal.md`
+  - `openspec/changes/issue-1-improve-create-pr-branch-flow/design.md`
+  - `openspec/changes/issue-1-improve-create-pr-branch-flow/specs/**/*.md`
+  - `openspec/changes/issue-1-improve-create-pr-branch-flow/tasks.md`
+  - `openspec/changes/issue-1-improve-create-pr-branch-flow/tests/*.md`
+
+## Residual Risk
+
+- This change updates workflow instructions and OpenSpec artifacts, not executable enforcement.
+- Branch collision and unrelated dirty worktree handling still depend on future agents following the updated guidance.
+- The GitHub-backed PR exists as draft PR #6 and this review artifact still needs to be committed, pushed, and posted with `/github:post-review 6` before review sync and merge.
+
+## Verdict
+
+Pass. The implementation satisfies the approved artifacts, all tasks are complete, required scenario coverage exists, and no blocking workflow-gate issue was found.

--- a/openspec/changes/issue-1-improve-create-pr-branch-flow/specs/github-orchestration-skills/spec.md
+++ b/openspec/changes/issue-1-improve-create-pr-branch-flow/specs/github-orchestration-skills/spec.md
@@ -1,0 +1,28 @@
+## MODIFIED Requirements
+
+### Requirement: GitHub orchestration skills
+WorkLoop SHALL provide dedicated GitHub orchestration skill instructions that operate around the existing OpenSpec workflow.
+
+#### Scenario: Required skill set exists
+- **WHEN** the GitHub orchestration workflow is implemented
+- **THEN** WorkLoop MUST include skill instructions for `/github:create-issue`, `/github:create-pr`, `/github:post-review`, `/github:sync-review`, `/github:address-comments`, and `/github:merge`
+
+#### Scenario: Core skills hand off to orchestration skills
+- **WHEN** core OpenSpec skills finish stages that require GitHub durability
+- **THEN** those skills MUST hand off to the appropriate GitHub orchestration skill instead of bypassing GitHub gates
+
+#### Scenario: Create PR starts on main
+- **WHEN** `/github:create-pr` starts from `main` or the default base branch with publishable local work
+- **THEN** it MUST create and switch to a `codex/<issue-or-change-slug>` branch before committing, pushing, or creating the PR
+
+#### Scenario: Create PR starts on existing work branch
+- **WHEN** `/github:create-pr` starts from a non-main work branch selected by the human
+- **THEN** it MUST preserve that branch and use it as the PR head branch unless the branch is unsafe to publish
+
+#### Scenario: Create PR publishes local work
+- **WHEN** `/github:create-pr` has a safe work branch, issue linkage, OpenSpec change path, verification, residual risk, and publishable local changes
+- **THEN** it MUST stage scoped changes, create an intentional commit, push the branch, and create or update a draft PR through GitHub MCP/plugin
+
+#### Scenario: Create PR cannot publish safely
+- **WHEN** repository context, issue linkage, branch safety, scoped local changes, verification, or residual risk is unclear
+- **THEN** `/github:create-pr` MUST block with a handoff instead of committing, pushing, or creating a misleading PR

--- a/openspec/changes/issue-1-improve-create-pr-branch-flow/tasks.md
+++ b/openspec/changes/issue-1-improve-create-pr-branch-flow/tasks.md
@@ -1,0 +1,17 @@
+## 1. Spec Contract
+
+- [x] 1.1 Update active `github-orchestration-skills` spec for `/github:create-pr` branch creation and publish behavior.
+- [x] 1.2 Verify the delta spec includes main/default-branch, existing work branch, publish, and blocked-state scenarios.
+
+## 2. Skill Behavior
+
+- [x] 2.1 Update `.codex/skills/github-create-pr/SKILL.md` to create and switch to `codex/<issue-or-change-slug>` when starting on `main` or the default branch.
+- [x] 2.2 Preserve existing non-main branch behavior when the human already selected a work branch.
+- [x] 2.3 Add safe staging, commit, push, and draft PR creation guidance.
+- [x] 2.4 Keep blockers for missing issue linkage, unclear scope, unsafe branch publication, missing verification, or missing residual risk.
+
+## 3. Verification
+
+- [x] 3.1 Generate test scenarios with `/tdd issue-1-improve-create-pr-branch-flow`.
+- [x] 3.2 Run OpenSpec validation for `issue-1-improve-create-pr-branch-flow`.
+- [x] 3.3 Search `/github:create-pr` guidance to verify it no longer blocks only because current branch is `main`.

--- a/openspec/changes/issue-1-improve-create-pr-branch-flow/tests/1-create-pr-branch-selection.md
+++ b/openspec/changes/issue-1-improve-create-pr-branch-flow/tests/1-create-pr-branch-selection.md
@@ -1,0 +1,48 @@
+# Test Scenario: 1 create-pr-branch-selection
+
+- Source task: 1.1 Update active `github-orchestration-skills` spec for `/github:create-pr` branch creation and publish behavior.
+- Source task: 1.2 Verify the delta spec includes main/default-branch, existing work branch, publish, and blocked-state scenarios.
+- Source task: 2.1 Update `.codex/skills/github-create-pr/SKILL.md` to create and switch to `codex/<issue-or-change-slug>` when starting on `main` or the default branch.
+- Source task: 2.2 Preserve existing non-main branch behavior when the human already selected a work branch.
+- Related requirements:
+  - `github-orchestration-skills`: Create PR starts on main.
+  - `github-orchestration-skills`: Create PR starts on existing work branch.
+- Assumptions:
+  - Repository default base branch is discoverable from local git or GitHub metadata.
+  - Issue link and OpenSpec change name can produce a stable branch slug.
+  - Branch prefix remains `codex/`.
+
+## Happy Path
+
+- Khi `/github:create-pr issue-1-improve-create-pr-branch-flow` chạy từ `main` hoặc default base branch
+- Và local work thuộc đúng OpenSpec change, có issue link, verification, và residual risk
+- Thì skill tạo và switch sang branch `codex/issue-1-improve-create-pr-branch-flow` trước khi stage, commit, push, hoặc tạo PR.
+- Khi `/github:create-pr` chạy từ non-main work branch do human đã chọn
+- Thì skill giữ branch đó làm PR head branch, miễn branch an toàn để publish.
+
+## Edge Cases
+
+- Current branch tên khác `main` nhưng trùng default base branch của repo.
+- Branch `codex/issue-1-improve-create-pr-branch-flow` đã tồn tại và trỏ đúng intended work; skill dùng lại thay vì tạo branch mới.
+- Human cung cấp branch hint khác `codex/` nhưng branch đó đã là work branch hợp lệ; skill không tự đổi branch nếu không cần.
+- Issue number có sẵn nhưng change slug dài; branch name vẫn readable và không chứa ký tự không hợp lệ.
+
+## Error Cases
+
+- Branch đích đã tồn tại nhưng trỏ tới work khác.
+- Current branch là non-main nhưng có upstream/base không rõ hoặc có dấu hiệu unsafe to publish.
+- Không xác định được issue number hoặc change slug để tạo branch an toàn.
+- Có unrelated dirty changes khiến scope branch không rõ.
+
+## Expected Outcomes
+
+- `/github:create-pr` không block chỉ vì đang ở `main`.
+- Skill chỉ tạo/switch branch trước publish khi branch context an toàn.
+- Human-selected non-main branch được giữ nguyên khi hợp lệ.
+- Unsafe branch collision hoặc unclear branch context block với handoff rõ.
+
+## Notes for Implementation
+
+- Branch creation phải xảy ra trước staging/commit.
+- Không publish từ `main` hoặc default base branch.
+- Không force-update branch đã tồn tại nếu chưa xác minh nó thuộc intended work.

--- a/openspec/changes/issue-1-improve-create-pr-branch-flow/tests/2-create-pr-safe-publish.md
+++ b/openspec/changes/issue-1-improve-create-pr-branch-flow/tests/2-create-pr-safe-publish.md
@@ -1,0 +1,50 @@
+# Test Scenario: 2 create-pr-safe-publish
+
+- Source task: 2.3 Add safe staging, commit, push, and draft PR creation guidance.
+- Source task: 2.4 Keep blockers for missing issue linkage, unclear scope, unsafe branch publication, missing verification, or missing residual risk.
+- Related requirements:
+  - `github-orchestration-skills`: Create PR publishes local work.
+  - `github-orchestration-skills`: Create PR cannot publish safely.
+- Assumptions:
+  - GitHub MCP/plugin is available for PR create/update.
+  - Local git commands are available for branch, stage, commit, and push.
+  - The PR body shape still requires issue link, OpenSpec path, problem, approach, verification, and residual risk.
+
+## Happy Path
+
+- Khi `/github:create-pr` có safe work branch, issue linkage, OpenSpec change path, scoped local changes, verification notes, và residual risk
+- Thì skill stage đúng files thuộc scope change.
+- Thì skill tạo intentional commit với message liên quan issue/change.
+- Thì skill push branch lên remote.
+- Thì skill tạo hoặc update draft PR qua GitHub MCP/plugin.
+- Thì PR body có đủ linked issue, OpenSpec path, problem, approach, verification, residual risk, và links.
+
+## Edge Cases
+
+- Đã có draft PR cho branch hiện tại; skill update PR body thay vì tạo PR trùng.
+- Không có file code runtime, chỉ có skill/docs/OpenSpec artifacts; vẫn publish nếu scope và verification rõ.
+- Có untracked unrelated OpenSpec change khác; skill không stage file đó và phải ghi rõ nếu bỏ qua hoặc block nếu không phân biệt được.
+- Verification có lệnh pass và một residual risk rõ; PR vẫn hợp lệ dù không có runnable tests.
+
+## Error Cases
+
+- Missing issue linkage và human chưa accept missing linkage.
+- OpenSpec change path không tồn tại.
+- Verification section sẽ bị bỏ trống hoặc chỉ ghi chung chung.
+- Residual risk bị bỏ trống.
+- Dirty worktree chứa unrelated changes không thể tách an toàn.
+- GitHub MCP/plugin không có quyền tạo/update PR.
+- Branch push thất bại hoặc upstream không rõ.
+
+## Expected Outcomes
+
+- Local work chỉ được commit/push khi scope rõ.
+- PR draft không được tạo với body thiếu verification hoặc residual risk.
+- Missing issue, missing OpenSpec path, unsafe dirty state, hoặc branch publication failure block trước khi mutate remote.
+- Handoff luôn nêu current state, done, needs human, next command, blockers, links.
+
+## Notes for Implementation
+
+- Stage bằng path cụ thể; không dùng publish-whole-worktree nếu có unrelated changes.
+- Nếu phải block, không tạo commit “partial” làm worktree khó hiểu hơn.
+- PR create/update phải dùng GitHub MCP/plugin, không custom HTTP client.

--- a/openspec/changes/issue-1-improve-create-pr-branch-flow/tests/3-verification.md
+++ b/openspec/changes/issue-1-improve-create-pr-branch-flow/tests/3-verification.md
@@ -1,0 +1,47 @@
+# Test Scenario: 3 verification
+
+- Source task: 3.1 Generate test scenarios with `/tdd issue-1-improve-create-pr-branch-flow`.
+- Source task: 3.2 Run OpenSpec validation for `issue-1-improve-create-pr-branch-flow`.
+- Source task: 3.3 Search `/github:create-pr` guidance to verify it no longer blocks only because current branch is `main`.
+- Related requirements:
+  - `github-orchestration-skills`: Create PR starts on main.
+  - `github-orchestration-skills`: Create PR starts on existing work branch.
+  - `github-orchestration-skills`: Create PR publishes local work.
+  - `github-orchestration-skills`: Create PR cannot publish safely.
+- Assumptions:
+  - `/tdd` uses scenario mode because no runnable test framework is detected.
+  - `/apply` or human verification will run OpenSpec validation after implementation.
+
+## Happy Path
+
+- Khi `/tdd issue-1-improve-create-pr-branch-flow` hoàn tất
+- Thì `tests/` có scenario coverage cho main/default branch start, existing work branch, safe publish, blocked states, missing issue, missing verification, và residual risk.
+- Khi implementation xong
+- Thì `openspec validate issue-1-improve-create-pr-branch-flow --strict` pass.
+- Khi search `.codex/skills/github-create-pr/SKILL.md`
+- Thì không còn guidance block chỉ vì current branch là `main`; thay vào đó guidance tạo/switch sang `codex/` branch khi safe.
+
+## Edge Cases
+
+- Search vẫn thấy chữ `main` trong context blocker, nhưng wording phải phân biệt unsafe branch với supported main-start flow.
+- Validation pass nhưng scenarios thiếu unsafe dirty state; coverage review phải bắt thiếu sót này.
+- Existing non-main branch guidance tồn tại nhưng không nêu unsafe publish blocker; coverage review phải bắt thiếu sót này.
+
+## Error Cases
+
+- Không có scenario test cho starting on `main`.
+- Không có scenario test cho preserving existing work branch.
+- Không có scenario test cho missing issue linkage, missing verification, hoặc missing residual risk.
+- `/github:create-pr` guidance vẫn nói block khi current branch là `main` mà không có create-branch path.
+- TDD output claim đã chạy validation, trái guardrail.
+
+## Expected Outcomes
+
+- Scenario tests đủ để `/apply` dùng làm behavioral context.
+- Verification task có tiêu chí cụ thể, không chỉ checklist chung chung.
+- Change không được coi complete nếu `/github:create-pr` vẫn block mechanical main-start flow.
+
+## Notes for Implementation
+
+- `/tdd` không chạy validation.
+- Sau approval, bước tiếp theo là `/apply issue-1-improve-create-pr-branch-flow`.


### PR DESCRIPTION
## Problem

Refs #1.

`/github:create-pr` blocked when local work started on `main`, even though `main` is the normal pre-publish state before Codex creates a PR branch. That made the GitHub-backed handoff require manual branch setup.

## Approach

- Update `/github:create-pr` guidance so `main` or the default base branch is a supported starting point.
- Require creating or switching to a safe `codex/issue-<number>-<slug>` branch before staging, committing, pushing, or creating the PR.
- Preserve an existing non-main human-selected work branch when it is safe to publish.
- Add safe staging, commit, push, draft PR create/update, and blocked-state guidance.
- Add OpenSpec change artifacts and scenario tests for branch selection, safe publish, and verification.

## Verification

- `openspec validate issue-1-improve-create-pr-branch-flow --strict`
- `git diff --check`
- Search guidance confirms `/github:create-pr` no longer blocks only because current branch is `main`; it only blocks if a safe `codex/` branch cannot be created or selected.
- This PR was created from local `main` by first switching to `codex/issue-1-improve-create-pr-branch-flow`, proving the new flow shape manually.

## OpenSpec

- `openspec/changes/issue-1-improve-create-pr-branch-flow/`
- Tasks complete: 9/9
- Scenario tests:
  - `tests/1-create-pr-branch-selection.md`
  - `tests/2-create-pr-safe-publish.md`
  - `tests/3-verification.md`

## Residual Risk

- This change updates skill instructions and OpenSpec artifacts, not executable enforcement.
- Branch collision detection remains instruction-level and depends on future agents checking local/remote branch state before publish.

## Links

- Issue: #1
- OpenSpec change: `openspec/changes/issue-1-improve-create-pr-branch-flow/`