### PR TITLE
Add spec context discovery to propose workflow

### DIFF
--- a/.codex/skills/propose/SKILL.md
+++ b/.codex/skills/propose/SKILL.md
@@ -49,7 +49,54 @@ After this, decide whether `/design <name>` is required. Low-risk changes may sk
 
    Check if `openspec/changes/<name>/brief.md` exists. If yes, read it — use its content as additional context when creating all artifacts (problem, goal, scope, constraints, acceptance criteria). Do NOT mention this to the user unless relevant.
 
-4. **Get the artifact build order**
+4. **Discover existing spec context**
+
+   Before creating or updating any planning artifact, run Spec Context Discovery
+   using the user request and `brief.md` if present.
+
+   a. **Extract lightweight search terms**
+   Identify terms from:
+   - domain nouns (e.g., auth, billing, workflow)
+   - user or system actions (e.g., login, export, validate)
+   - entities (e.g., credential, issue, proposal)
+   - UI/API/workflow surfaces (e.g., login screen, `/propose`, endpoint names)
+   - error, validation, security, or trust-boundary terms
+   - likely capability names
+
+   b. **Search active specs first**
+   Search `openspec/specs/**` with the extracted terms. Prefer `rg` when
+   available. Read every matched active spec file that appears relevant before
+   deciding whether a capability is new or modified.
+
+   c. **Search active changes next**
+   Search `openspec/changes/**` with the extracted terms, excluding
+   `openspec/changes/archive/**`. Read related active change artifacts when they
+   may overlap with the requested scope. Treat the current change separately so
+   it is not reported as a conflict with itself.
+
+   d. **Clarify ambiguous overlap**
+   If another active change overlaps the same domain, capability, or
+   requirements, ask whether to continue the existing change, merge scope, or
+   proceed with the new change. Do not silently create conflicting planning
+   artifacts.
+
+   e. **Search archive only when needed**
+   Do not search `openspec/changes/archive/**` by default. Search archived
+   changes only when active specs and active changes are insufficient,
+   conflicting, or missing rationale needed for a safe proposal. If archive
+   context influences the artifacts, record why it was needed.
+
+   f. **Use discovery for artifact generation**
+   Use discovered context to decide:
+   - existing capability vs new capability
+   - `ADDED`, `MODIFIED`, `REMOVED`, or `RENAMED` delta operation
+   - whether human clarification is needed before writing artifacts
+
+   Record concise discovery evidence in generated artifacts, preferably in
+   `proposal.md` under `Existing Context Reviewed`: related active specs,
+   related active changes, and short impact notes. Do not copy full spec content.
+
+5. **Get the artifact build order**
 
    ```bash
    openspec status --change "<name>" --json
@@ -59,7 +106,7 @@ After this, decide whether `/design <name>` is required. Low-risk changes may sk
    - artifact IDs and dependency order
    - `artifacts`: list of all artifacts with their status and dependencies
 
-4. **Create planning artifacts in sequence**
+6. **Create planning artifacts in sequence**
 
    Use the **TodoWrite tool** to track progress through the artifacts.
 
@@ -97,12 +144,12 @@ After this, decide whether `/design <name>` is required. Low-risk changes may sk
    - Use **AskUserQuestion tool** to clarify
    - Then continue with creation
 
-5. **Show final status**
+7. **Show final status**
    ```bash
    openspec status --change "<name>"
    ```
 
-6. **Decide the next handoff**
+8. **Decide the next handoff**
 
    Evaluate whether the change needs the `/design` review step.
 
@@ -141,6 +188,9 @@ After completing all artifacts, summarize:
 
 - Follow the `instruction` field from `openspec instructions` for each artifact type
 - The schema defines what each artifact should contain - follow it
+- Run Spec Context Discovery before creating or updating planning artifacts
+- Use discovered active specs and active changes for capability selection and delta operation choice
+- Record related specs and active changes concisely; do not paste full matched specs into artifacts
 - Read dependency artifacts for context before creating new ones
 - Use `template` as the structure for your output file - fill in its sections
 - **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
@@ -153,6 +203,8 @@ After completing all artifacts, summarize:
 - Do not suggest `/apply` directly after `/propose`
 - Always decide and explain whether `/design` review is required or can be skipped
 - Do not create tests from `/propose`; use `/tdd`
+- Do not generate planning artifacts before searching relevant active specs and active changes
+- Do not search archived changes by default; use archive only for conflict or rationale gaps
 - Always read dependency artifacts before creating a new one
 - If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
 - If a change with that name already exists, ask if user wants to continue it or create a new one

--- a/openspec/changes/issue-7-spec-context-discovery-propose/.openspec.yaml
+++ b/openspec/changes/issue-7-spec-context-discovery-propose/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven-custom
+created: 2026-05-04

--- a/openspec/changes/issue-7-spec-context-discovery-propose/brief.md
+++ b/openspec/changes/issue-7-spec-context-discovery-propose/brief.md
@@ -1,0 +1,52 @@
+# Brief: Spec Context Discovery Propose
+
+## Problem
+
+`/propose` hiện có thể tạo proposal/spec/design/tasks từ request hiện tại mà không chắc đã tìm và đọc các spec cũ liên quan đến cùng domain, màn hình, action hoặc capability.
+
+Ví dụ: request "bổ sung validate cho màn hình login" cần đọc spec liên quan đến login/auth/validation trước khi quyết định tạo capability mới hay sửa capability cũ.
+
+Nếu thiếu bước này, workflow có thể tạo requirement trùng, chọn `ADDED` sai thay vì `MODIFIED`, bỏ sót constraint cũ, hoặc conflict với active change khác.
+
+## Goal
+
+Thêm bước Spec Context Discovery nhẹ vào `/propose` để mọi change mới được tạo dựa trên context OpenSpec hiện có trước khi sinh proposal/spec/design/tasks.
+
+## Scope
+
+### In scope
+
+- Cập nhật `/propose` để extract keyword từ user request và `brief.md` nếu có.
+- Search active specs trong `openspec/specs/**`.
+- Search active changes trong `openspec/changes/**`, loại trừ `archive/**`.
+- Đọc matched specs/active change artifacts trước khi phân loại capability.
+- Dùng context tìm được để quyết định new vs existing capability.
+- Dùng context tìm được để chọn `ADDED`, `MODIFIED`, `REMOVED`, hoặc `RENAMED`.
+- Ghi related specs và overlapping active changes vào artifact một cách ngắn gọn, reviewable.
+- Chỉ search archive khi active context thiếu, conflict, hoặc cần rationale.
+
+### Out of scope
+
+- Không thêm vector DB hoặc embedding infra ở bước này.
+- Không bắt buộc search toàn bộ archive cho mọi proposal.
+- Không sửa application code nếu proposal sau này không chỉ ra nhu cầu rõ ràng.
+
+## Constraints
+
+- Ưu tiên workflow nhẹ, dùng keyword/spec discovery trước, chưa dùng semantic infra nặng.
+- Active specs là source of truth chính.
+- Active changes cần được kiểm tra để tránh conflict.
+- Archive chỉ là lịch sử/rationale, không phải context mặc định.
+- Thay đổi nên tập trung vào workflow/spec/skill artifacts.
+
+## Acceptance Criteria
+
+- [ ] `/propose` thực hiện Spec Context Discovery trước khi tạo hoặc cập nhật `proposal.md`, `specs/**/*.md`, `design.md`, và `tasks.md`.
+- [ ] Discovery search active specs bằng terms extract từ request/brief.
+- [ ] Discovery search active changes và loại trừ archived changes.
+- [ ] Matched specs được đọc trước khi phân loại capability.
+- [ ] Proposal generation phân biệt existing vs new capabilities dựa trên discovered context.
+- [ ] Spec generation dùng discovered context để chọn đúng `ADDED`, `MODIFIED`, `REMOVED`, hoặc `RENAMED`.
+- [ ] Generated artifacts ghi related specs và overlapping active changes ngắn gọn, reviewable.
+- [ ] `/propose` hỏi clarification khi capability mapping hoặc active-change overlap mơ hồ.
+- [ ] Archive search là optional, chỉ dùng khi cần conflict/rationale gap.

--- a/openspec/changes/issue-7-spec-context-discovery-propose/design.md
+++ b/openspec/changes/issue-7-spec-context-discovery-propose/design.md
@@ -1,0 +1,116 @@
+## Context
+
+`/propose` currently reads the current change artifacts and schema instructions, but the skill instructions do not explicitly require discovering related active specs or overlapping active changes before generating planning artifacts. The schema hints that capability selection should research existing specs, but that guidance is embedded inside artifact instructions instead of being a first-class workflow step.
+
+This change introduces Spec Context Discovery as an explicit pre-artifact step in `/propose`. The discovery result informs capability classification, delta operation choice, and concise context evidence in generated artifacts.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make `/propose` search active specs before choosing new vs modified capabilities.
+- Make `/propose` search active changes while excluding archived changes by default.
+- Require matched specs and overlapping active change artifacts to be read before planning artifacts are generated.
+- Record concise discovery evidence in generated artifacts.
+- Keep the workflow lightweight, deterministic, and easy to review.
+
+**Non-Goals:**
+
+- Add embeddings, vector search, or a semantic search service.
+- Search all archived changes by default.
+- Change `/apply`, `/review`, `/archive`, or GitHub orchestration behavior.
+- Add a new standalone discovery artifact unless a later change proves it is needed.
+
+## Proposed Architecture
+
+`/propose` becomes a three-stage planning workflow:
+
+1. Intake:
+   - Resolve or create the change.
+   - Read `brief.md` when present.
+   - Extract search terms from request and brief: domain nouns, user actions, entities, UI/API surfaces, error/validation/security terms, and likely capability names.
+
+2. Spec Context Discovery:
+   - Search `openspec/specs/**` using the extracted terms.
+   - Read matched active spec files before capability classification.
+   - Search `openspec/changes/**` for related active changes while excluding `openspec/changes/archive/**`.
+   - Ask for clarification when another active change overlaps or capability mapping is ambiguous.
+   - Search archive only when active context is insufficient, conflicting, or missing rationale.
+
+3. Artifact generation:
+   - Generate `proposal.md`, `specs/**/*.md`, `design.md`, and `tasks.md` in the existing dependency order.
+   - Use discovered context to decide new vs modified capabilities and `ADDED` vs `MODIFIED` vs `REMOVED` vs `RENAMED`.
+   - Record concise related specs and related active changes in the proposal artifact.
+
+No runtime dependency is introduced. Implementation should update instruction surfaces only unless a small helper is later justified during `/apply`.
+
+## Impact Map
+
+- `.codex/skills/propose/SKILL.md`
+  - Add the explicit discovery stage before artifact build order.
+  - Define term extraction, active spec search, active change search, clarification behavior, and archive-search limits.
+
+- `openspec/schemas/spec-driven-custom/schema.yaml`
+  - Align proposal instructions with discovery-before-capability-selection.
+  - Align specs instructions with discovered-context-based delta operation choice.
+
+- `openspec/schemas/spec-driven-custom/templates/proposal.md`
+  - Add a concise `Existing Context Reviewed` section.
+
+- `openspec/changes/issue-7-spec-context-discovery-propose/specs/propose-skill/spec.md`
+  - Defines the new `propose-skill` capability until archive sync promotes it to `openspec/specs/propose-skill/spec.md`.
+
+- Downstream workflow
+  - `/tdd`, `/apply`, `/review`, and `/archive` continue to consume artifacts normally. Their behavior should not change.
+
+## Decisions
+
+1. Put discovery before proposal creation.
+
+   Rationale: Capability classification happens in `proposal.md`; discovering related specs after proposal generation is too late.
+
+   Alternative rejected: rely on `/design` to catch missed context. That would allow wrong proposal capabilities and delta specs to exist before review.
+
+2. Use lightweight keyword/context discovery, not embeddings.
+
+   Rationale: Current repo size and workflow needs are served by deterministic `rg`-style discovery. New semantic infrastructure would add cost, dependencies, and verification complexity without clear need.
+
+   Alternative rejected: vector DB or embedding search. It is overbuilt for this change.
+
+3. Search active specs first, active changes second, archive only when needed.
+
+   Rationale: Active specs are current truth. Active changes identify in-flight conflict. Archive is historical rationale and can create noise if searched by default.
+
+   Alternative rejected: default archive search. It risks old decisions competing with current specs.
+
+4. Store discovery evidence in `proposal.md`.
+
+   Rationale: Reviewers need to see the context that shaped capability choices. Proposal is the right artifact because it owns capability selection.
+
+   Alternative rejected: duplicate the same evidence in `design.md`. Design may reference discovery when useful, but proposal should be the default durable record.
+
+5. Leave exact search command flexible, but require paths and exclusions.
+
+   Rationale: Skill guidance should require behavior, not overfit to one shell command. Implementation may use `rg`, CLI helpers, or another local search method as long as it searches active specs, searches active changes, and excludes archive by default.
+
+   Alternative rejected: hardcode a single `rg` recipe as the only valid implementation. That is brittle across future tooling.
+
+## Risks / Trade-offs
+
+- [Risk] Keyword search misses synonyms or domain-specific names -> Mitigation: require multiple term classes and ask for clarification when mapping remains ambiguous.
+- [Risk] Discovery evidence bloats proposals -> Mitigation: keep evidence to related specs, related active changes, and short impact notes.
+- [Risk] Archive rationale is skipped when it matters -> Mitigation: allow archive search when active context is insufficient, conflicting, or missing rationale, and record why archive context influenced the artifacts.
+- [Risk] Skill and schema instructions drift -> Mitigation: update both surfaces and verify `openspec instructions proposal/specs` still reinforces discovery.
+- [Risk] Active-change search flags the current change as overlap -> Mitigation: exclude or separately identify the current change when summarizing overlaps.
+
+## Open Questions
+
+- None blocking. Accepted defaults:
+  - Discovery evidence lives in `proposal.md` by default.
+  - Exact search command remains flexible; required behavior is defined by searched paths, archive exclusion, and read-before-write contract.
+
+## Review Notes
+
+- Specialist perspectives applied internally: Architecture, Impact, Failure Modes, Data Flow, and Review and Docs.
+- Security and Performance were not selected because the change does not alter auth, authorization, sensitive data handling, latency, throughput, or runtime scaling paths.
+- Main refinement from the initial design: resolved both open questions with concrete defaults and added `Proposed Architecture` plus `Impact Map`.

--- a/openspec/changes/issue-7-spec-context-discovery-propose/proposal.md
+++ b/openspec/changes/issue-7-spec-context-discovery-propose/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+`/propose` needs to create planning artifacts from repository truth, not just the current request or chat context. Today it can miss existing specs for the same domain, screen, action, or capability, which can cause duplicate requirements, incorrect `ADDED` vs `MODIFIED` delta choices, or conflicts with active changes.
+
+## What Changes
+
+- Add a Spec Context Discovery step to `/propose` before it generates proposal, specs, design, and tasks.
+- Require `/propose` to extract lightweight search terms from the user request and optional `brief.md`.
+- Require `/propose` to search active specs and active changes before capability classification.
+- Require matched specs and active change artifacts to be read before deciding new vs modified capabilities and delta operations.
+- Require concise context evidence in generated planning artifacts.
+- Keep archive search optional and limited to conflict, missing rationale, or insufficient active context cases.
+
+## Existing Context Reviewed
+
+- `openspec/specs/github-workflow/spec.md`
+  - Relevant context: WorkLoop artifacts must provide durable context without relying on chat history.
+  - Impact: This change strengthens pre-proposal artifact grounding but does not change GitHub delivery flow.
+- `openspec/specs/code-skill/spec.md`
+  - Relevant context: `/apply` already has explicit implementation context loading.
+  - Impact: `/propose` needs a similar explicit context-discovery contract for planning.
+- Active changes
+  - `issue-7-spec-context-discovery-propose` is the only active matching change found.
+
+## Capabilities
+
+### New Capabilities
+
+- `propose-skill`: Defines how `/propose` discovers existing OpenSpec context before generating planning artifacts.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- `.codex/skills/propose/SKILL.md`
+- `openspec/schemas/spec-driven-custom/schema.yaml`
+- `openspec/schemas/spec-driven-custom/templates/proposal.md`
+- New active spec capability: `openspec/specs/propose-skill/spec.md` after archive sync

--- a/openspec/changes/issue-7-spec-context-discovery-propose/review.md
+++ b/openspec/changes/issue-7-spec-context-discovery-propose/review.md
@@ -1,0 +1,38 @@
+verdict: pass
+blocking_findings: none
+reviewed_ref: 9c4d7ed337cee163a3936659f74722aa95293bc9
+reviewed_diff: 5825fbfa173cdbc04805c50bbe45845964fc40c59970af043f0f63f6f45c9f12
+reviewed_implementation_diff: 5825fbfa173cdbc04805c50bbe45845964fc40c59970af043f0f63f6f45c9f12
+reviewed_paths_excluded: openspec/changes/issue-7-spec-context-discovery-propose/review.md
+reviewed_at: 2026-05-04T15:11:26Z
+
+## Findings
+
+No blocking findings.
+
+The PR implementation matches the approved artifacts:
+
+- `/propose` now has an explicit Spec Context Discovery stage before artifact generation.
+- Proposal schema/template now records concise related active specs and active changes in `Existing Context Reviewed`.
+- Specs instructions now use discovered context for `ADDED`, `MODIFIED`, `REMOVED`, and `RENAMED` choices.
+- Archive search remains optional and rationale-driven, not default.
+- No embedding/vector dependency was introduced.
+
+## Tests Run
+
+- `openspec validate --changes issue-7-spec-context-discovery-propose`
+- `openspec status --change issue-7-spec-context-discovery-propose`
+- `openspec instructions apply --change issue-7-spec-context-discovery-propose --json`
+- `openspec instructions proposal --change issue-7-spec-context-discovery-propose --json`
+- `openspec instructions specs --change issue-7-spec-context-discovery-propose --json`
+- Reviewed PR diff from `main...HEAD` against proposal, specs, design, tasks, and scenario tests.
+
+## Residual Risk
+
+- Keyword-based discovery can still miss synonyms or domain-specific names. The implemented guidance mitigates this by requiring multiple term classes and clarification when capability mapping is ambiguous.
+- The local worktree contains unrelated unstaged changes in `.codex/skills/explore/SKILL.md` and `docs/ai-native-codex-workflow.md`. They are not part of PR #8, but the required review fingerprint commands include current local dirty state because the review contract excludes only this `review.md` path.
+- PR #8 is still draft and must be posted/synced through the GitHub review workflow before merge/archive.
+
+## Verdict
+
+Pass. The implementation satisfies the approved scope and scenario tests. No blocking findings remain.

--- a/openspec/changes/issue-7-spec-context-discovery-propose/specs/propose-skill/spec.md
+++ b/openspec/changes/issue-7-spec-context-discovery-propose/specs/propose-skill/spec.md
@@ -1,0 +1,52 @@
+## ADDED Requirements
+
+### Requirement: Discover existing spec context before proposal generation
+The `/propose` workflow SHALL discover existing OpenSpec context before creating or updating planning artifacts for a change.
+
+#### Scenario: Active specs are searched before capability classification
+- **WHEN** `/propose <change-name>` runs with a user request or `brief.md`
+- **THEN** the workflow MUST extract relevant domain, action, entity, surface, and likely capability terms
+- **AND** the workflow MUST search `openspec/specs/**` for matching active specs before deciding whether capabilities are new or modified
+
+#### Scenario: Matched active specs are read
+- **WHEN** the active spec search finds matching spec files
+- **THEN** `/propose` MUST read the matched spec files before creating `proposal.md` or delta specs
+- **AND** `/propose` MUST use those specs to decide whether a delta should use `ADDED`, `MODIFIED`, `REMOVED`, or `RENAMED`
+
+### Requirement: Detect overlapping active changes
+The `/propose` workflow SHALL check active OpenSpec changes for overlap before creating planning artifacts.
+
+#### Scenario: Active changes are searched without archive noise
+- **WHEN** `/propose <change-name>` runs
+- **THEN** the workflow MUST search `openspec/changes/**` for related active change artifacts
+- **AND** the workflow MUST exclude `openspec/changes/archive/**` from the default active-change search
+
+#### Scenario: Ambiguous overlap requires clarification
+- **WHEN** `/propose` finds another active change with overlapping domain, capability, or requirements
+- **THEN** `/propose` MUST ask whether to continue the existing change, merge scope, or proceed with the new change
+- **AND** `/propose` MUST NOT silently create conflicting planning artifacts
+
+### Requirement: Record discovered context in planning artifacts
+The `/propose` workflow SHALL record concise context-discovery evidence in generated planning artifacts.
+
+#### Scenario: Related context is documented
+- **WHEN** `/propose` creates or updates planning artifacts
+- **THEN** the generated artifacts MUST identify related active specs that were reviewed
+- **AND** the generated artifacts MUST identify related active changes or state that none were found
+
+#### Scenario: Context affects capability decisions
+- **WHEN** discovered context causes `/propose` to choose an existing capability instead of a new capability
+- **THEN** `proposal.md` MUST list that capability under modified capabilities
+- **AND** the related delta spec MUST use the existing capability folder name from `openspec/specs/<capability>/`
+
+### Requirement: Limit archive search to rationale gaps
+The `/propose` workflow SHALL avoid searching archived changes by default.
+
+#### Scenario: Archive search is skipped for sufficient active context
+- **WHEN** active specs and active changes provide enough context to classify the change
+- **THEN** `/propose` MUST NOT search `openspec/changes/archive/**` as part of default context discovery
+
+#### Scenario: Archive search is allowed for conflict or rationale
+- **WHEN** active context is insufficient, conflicting, or missing rationale needed for a safe proposal
+- **THEN** `/propose` MAY search archived changes
+- **AND** `/propose` MUST record why archive context was needed if it influenced generated artifacts

--- a/openspec/changes/issue-7-spec-context-discovery-propose/tasks.md
+++ b/openspec/changes/issue-7-spec-context-discovery-propose/tasks.md
@@ -1,0 +1,27 @@
+## 1. Spec and Artifact Surface
+
+- [x] 1.1 Add active delta spec coverage for `/propose` Spec Context Discovery.
+- [x] 1.2 Update proposal artifact guidance to record related specs and active changes reviewed.
+- [x] 1.3 Update proposal template with a concise context-reviewed section.
+
+## 2. Propose Workflow Guidance
+
+- [x] 2.1 Update `.codex/skills/propose/SKILL.md` to run Spec Context Discovery before artifact generation.
+- [x] 2.2 Define request/brief term extraction for domain, action, entity, UI surface, and likely capability terms.
+- [x] 2.3 Define active spec search and matched-spec read behavior before capability classification.
+- [x] 2.4 Define active change overlap search while excluding archived changes by default.
+- [x] 2.5 Define clarification behavior when capability mapping or active-change overlap is ambiguous.
+- [x] 2.6 Define archive search as optional and rationale-driven only.
+
+## 3. Schema Instruction Alignment
+
+- [x] 3.1 Update `openspec/schemas/spec-driven-custom/schema.yaml` proposal instructions to require discovery before capability selection.
+- [x] 3.2 Update specs instructions to require using discovered context for `ADDED`, `MODIFIED`, `REMOVED`, and `RENAMED` choices.
+- [x] 3.3 Keep schema and skill wording aligned so `openspec instructions proposal/specs` does not weaken `/propose` guidance.
+
+## 4. Verification
+
+- [x] 4.1 Run OpenSpec validation for `issue-7-spec-context-discovery-propose`.
+- [x] 4.2 Search active workflow instructions for `/propose` paths that create artifacts without discovery.
+- [x] 4.3 Verify archive search is not required by default in active guidance.
+- [x] 4.4 Verify generated artifact guidance remains concise and does not introduce embedding/vector dependencies.

--- a/openspec/changes/issue-7-spec-context-discovery-propose/tests/1-spec-and-artifact-surface.md
+++ b/openspec/changes/issue-7-spec-context-discovery-propose/tests/1-spec-and-artifact-surface.md
@@ -1,0 +1,43 @@
+# Test Scenario: 1 spec and artifact surface
+
+- Source tasks:
+  - 1.1 Add active delta spec coverage for `/propose` Spec Context Discovery.
+  - 1.2 Update proposal artifact guidance to record related specs and active changes reviewed.
+  - 1.3 Update proposal template with a concise context-reviewed section.
+- Related requirements:
+  - Discover existing spec context before proposal generation
+  - Record discovered context in planning artifacts
+- Assumptions:
+  - This change defines a new `propose-skill` capability because no active spec currently owns `/propose` behavior.
+
+## Happy Path
+
+- Khi reviewer mở delta spec của change.
+- Thì spec có requirement mô tả `/propose` phải discover existing spec context trước khi tạo artifacts.
+- Thì spec có scenario cho active specs search, matched specs read, active changes search, artifact context evidence, và archive search limit.
+- Khi reviewer mở proposal template/guidance sau implementation.
+- Thì có section hoặc guidance rõ để ghi related active specs và related active changes ngắn gọn.
+
+## Edge Cases
+
+- Nếu không có related active specs.
+- Thì artifact guidance vẫn yêu cầu ghi rõ không tìm thấy related specs hoặc không có relevant active specs.
+- Nếu chỉ có active change hiện tại match search.
+- Thì guidance phải tránh xem current change như overlap conflict.
+
+## Error Cases
+
+- Nếu delta spec chỉ mô tả search chung chung nhưng không yêu cầu read matched specs trước capability classification.
+- Thì scenario fail vì không đủ read-before-write contract.
+- Nếu proposal template khuyến khích copy dài nội dung spec liên quan.
+- Thì scenario fail vì trái với constraint concise/reviewable.
+
+## Expected Outcomes
+
+- Spec-level behavior rõ, testable, dùng SHALL/MUST.
+- Artifact surface có chỗ ghi context discovery evidence.
+- Không tạo dependency hoặc artifact mới ngoài scope.
+
+## Notes for Implementation
+
+- Giữ context evidence ngắn: file path, requirement/context liên quan, impact ngắn.

--- a/openspec/changes/issue-7-spec-context-discovery-propose/tests/2-propose-workflow-guidance.md
+++ b/openspec/changes/issue-7-spec-context-discovery-propose/tests/2-propose-workflow-guidance.md
@@ -1,0 +1,52 @@
+# Test Scenario: 2 propose workflow guidance
+
+- Source tasks:
+  - 2.1 Update `.codex/skills/propose/SKILL.md` to run Spec Context Discovery before artifact generation.
+  - 2.2 Define request/brief term extraction for domain, action, entity, UI surface, and likely capability terms.
+  - 2.3 Define active spec search and matched-spec read behavior before capability classification.
+  - 2.4 Define active change overlap search while excluding archived changes by default.
+  - 2.5 Define clarification behavior when capability mapping or active-change overlap is ambiguous.
+  - 2.6 Define archive search as optional and rationale-driven only.
+- Related requirements:
+  - Discover existing spec context before proposal generation
+  - Detect overlapping active changes
+  - Limit archive search to rationale gaps
+- Assumptions:
+  - `/propose` remains instruction-driven; no new runtime command wrapper is required.
+
+## Happy Path
+
+- Khi `/propose <change-name>` chạy với request hoặc `brief.md`.
+- Thì skill guidance yêu cầu extract terms từ domain, action, entity, surface, error/validation/security terms, và likely capability names.
+- Thì guidance yêu cầu search `openspec/specs/**` trước capability classification.
+- Thì matched specs được đọc trước khi viết `proposal.md` hoặc delta spec.
+- Thì guidance yêu cầu search active changes trong `openspec/changes/**` và exclude `openspec/changes/archive/**`.
+- Thì artifact generation chỉ tiếp tục sau discovery.
+
+## Edge Cases
+
+- Nếu nhiều capability match ngang nhau.
+- Thì `/propose` phải hỏi clarification thay vì tự chọn.
+- Nếu active change khác overlap cùng capability/domain.
+- Thì `/propose` phải hỏi continue existing, merge scope, hoặc proceed new change.
+- Nếu active specs đủ rõ.
+- Thì archive search không chạy mặc định.
+
+## Error Cases
+
+- Nếu guidance vẫn cho phép tạo proposal trước rồi mới search specs.
+- Thì scenario fail.
+- Nếu guidance search toàn `openspec/changes/**` mà không exclude archive.
+- Thì scenario fail.
+- Nếu archive search là bước mặc định.
+- Thì scenario fail.
+
+## Expected Outcomes
+
+- `/propose` có pre-artifact discovery step rõ ràng.
+- Context discovery không phụ thuộc chat memory.
+- Active spec và active change context quyết định new vs modified capability.
+
+## Notes for Implementation
+
+- Không hardcode một command duy nhất nếu wording vẫn bắt buộc đúng paths/exclusions/read-before-write.

--- a/openspec/changes/issue-7-spec-context-discovery-propose/tests/3-schema-instruction-alignment.md
+++ b/openspec/changes/issue-7-spec-context-discovery-propose/tests/3-schema-instruction-alignment.md
@@ -1,0 +1,45 @@
+# Test Scenario: 3 schema instruction alignment
+
+- Source tasks:
+  - 3.1 Update `openspec/schemas/spec-driven-custom/schema.yaml` proposal instructions to require discovery before capability selection.
+  - 3.2 Update specs instructions to require using discovered context for `ADDED`, `MODIFIED`, `REMOVED`, and `RENAMED` choices.
+  - 3.3 Keep schema and skill wording aligned so `openspec instructions proposal/specs` does not weaken `/propose` guidance.
+- Related requirements:
+  - Discover existing spec context before proposal generation
+  - Record discovered context in planning artifacts
+- Assumptions:
+  - `openspec instructions proposal --change <name> --json` and `openspec instructions specs --change <name> --json` are used by `/propose`.
+
+## Happy Path
+
+- Khi chạy `openspec instructions proposal --change issue-7-spec-context-discovery-propose --json` sau implementation.
+- Thì instruction nói rõ phải discover active specs và active changes trước capability selection.
+- Khi chạy `openspec instructions specs --change issue-7-spec-context-discovery-propose --json`.
+- Thì instruction nói rõ phải dùng discovered context để chọn `ADDED`, `MODIFIED`, `REMOVED`, hoặc `RENAMED`.
+- Thì schema instruction không mâu thuẫn với `.codex/skills/propose/SKILL.md`.
+
+## Edge Cases
+
+- Nếu schema chỉ nói "Research existing specs" chung chung nhưng skill có discovery chi tiết.
+- Thì scenario nên fail vì schema vẫn quá yếu và dễ drift.
+- Nếu proposal instruction có discovery nhưng specs instruction không nhắc delta operation dựa trên discovered context.
+- Thì scenario fail vì spec generation vẫn có thể chọn sai delta operation.
+
+## Error Cases
+
+- Nếu `openspec instructions proposal` bỏ qua active change overlap.
+- Thì scenario fail.
+- Nếu schema instruction bắt archive search mặc định.
+- Thì scenario fail.
+- Nếu schema instruction nhắc embedding/vector DB.
+- Thì scenario fail vì ngoài scope.
+
+## Expected Outcomes
+
+- Skill và schema cùng mô tả một contract.
+- CLI-generated instructions không làm yếu behavior của `/propose`.
+- Proposal/spec instructions vẫn ngắn, không biến schema thành tutorial dài.
+
+## Notes for Implementation
+
+- Verify bằng chính output JSON của `openspec instructions`, không chỉ đọc YAML trực tiếp.

--- a/openspec/changes/issue-7-spec-context-discovery-propose/tests/4-verification.md
+++ b/openspec/changes/issue-7-spec-context-discovery-propose/tests/4-verification.md
@@ -1,0 +1,49 @@
+# Test Scenario: 4 verification
+
+- Source tasks:
+  - 4.1 Run OpenSpec validation for `issue-7-spec-context-discovery-propose`.
+  - 4.2 Search active workflow instructions for `/propose` paths that create artifacts without discovery.
+  - 4.3 Verify archive search is not required by default in active guidance.
+  - 4.4 Verify generated artifact guidance remains concise and does not introduce embedding/vector dependencies.
+- Related requirements:
+  - Detect overlapping active changes
+  - Limit archive search to rationale gaps
+  - Record discovered context in planning artifacts
+- Assumptions:
+  - Verification is documentation/spec-oriented because this change is workflow-instruction heavy.
+
+## Happy Path
+
+- Khi implementation xong.
+- Thì `openspec validate --changes issue-7-spec-context-discovery-propose` pass.
+- Thì search active guidance cho `/propose` không còn path tạo proposal/spec/design/tasks mà thiếu discovery step.
+- Thì active guidance nói archive search chỉ optional khi active context thiếu, conflict, hoặc cần rationale.
+- Thì search active guidance không thấy yêu cầu embedding, vector DB, hoặc semantic infrastructure.
+
+## Edge Cases
+
+- Nếu archived historical files vẫn nhắc old propose behavior.
+- Thì không fail nếu active guidance đã đúng và archive không được xem là active source.
+- Nếu một doc active nhắc `/propose` ở mức lifecycle nhưng không mô tả artifact generation.
+- Thì không fail nếu doc đó không phải instruction path tạo artifact.
+
+## Error Cases
+
+- Nếu `.codex/skills/propose/SKILL.md` vẫn cho tạo planning artifacts trực tiếp sau brief/status mà không discovery.
+- Thì scenario fail.
+- Nếu `openspec/schemas/spec-driven-custom/schema.yaml` vẫn chỉ có weak guidance không bắt discovery.
+- Thì scenario fail.
+- Nếu proposal template yêu cầu evidence dài hoặc full copied spec content.
+- Thì scenario fail.
+
+## Expected Outcomes
+
+- Change validate sạch.
+- Active propose workflow có discovery gate rõ.
+- Archive search không trở thành default.
+- Không thêm dependency hoặc infra ngoài scope.
+
+## Notes for Implementation
+
+- Search active paths trước: `.codex/skills/`, `openspec/schemas/`, `openspec/specs/`.
+- Phân biệt active guidance với `openspec/changes/archive/**`.

--- a/openspec/schemas/spec-driven-custom/schema.yaml
+++ b/openspec/schemas/spec-driven-custom/schema.yaml
@@ -19,16 +19,39 @@ artifacts:
       capabilities, modifications, or removals. Mark breaking changes with
       **BREAKING**.
 
+      - **Existing Context Reviewed**: Concise list of related active specs and
+      active changes reviewed before capability selection. Include path,
+      relevant requirement/context, and short impact note. If none were found,
+      state that explicitly. Do not copy full spec content.
+
       - **Capabilities**: Identify which specs will be created or modified:
         - **New Capabilities**: List capabilities being introduced. Each becomes a new `specs/<name>/spec.md`. Use kebab-case names (e.g., `user-auth`, `data-export`).
         - **Modified Capabilities**: List existing capabilities whose REQUIREMENTS are changing. Only include if spec-level behavior changes (not just implementation details). Each needs a delta spec file. Check `openspec/specs/` for existing spec names. Leave empty if no requirement changes.
       - **Impact**: Affected code, APIs, dependencies, or systems.
 
 
+      Before filling Capabilities, run Spec Context Discovery:
+      - Extract lightweight search terms from the user request and `brief.md`
+      when present: domain nouns, user or system actions, entities, UI/API or
+      workflow surfaces, error/validation/security terms, and likely capability
+      names.
+      - Search `openspec/specs/**` with those terms and read matched active
+      specs before deciding whether capabilities are new or modified.
+      - Search `openspec/changes/**` for overlapping active changes while
+      excluding `openspec/changes/archive/**`. Treat the current change
+      separately so it is not reported as a conflict with itself.
+      - Ask for clarification when capability mapping or active-change overlap
+      is ambiguous.
+      - Search archived changes only when active context is insufficient,
+      conflicting, or missing rationale needed for a safe proposal.
+
+
       IMPORTANT: The Capabilities section is critical. It creates the contract
       between
 
       proposal and specs phases. Research existing specs before filling this in.
+      Use discovered context to avoid duplicate requirements and to choose
+      existing vs new capabilities.
 
       Each capability listed here will need a corresponding spec file.
 
@@ -57,6 +80,12 @@ artifacts:
       - Modified capabilities: use the existing spec folder name from
       openspec/specs/<capability>/ when creating the delta spec at
       specs/<capability>/spec.md.
+
+      Use the Spec Context Discovery recorded in `proposal.md` before choosing
+      delta operations. Matched active specs determine whether behavior is new
+      (`ADDED`) or changes an existing requirement (`MODIFIED`). Related active
+      changes determine whether the spec needs clarification before writing a
+      potentially conflicting delta.
 
 
       Delta operations (use ## headers):

--- a/openspec/schemas/spec-driven-custom/templates/proposal.md
+++ b/openspec/schemas/spec-driven-custom/templates/proposal.md
@@ -6,6 +6,13 @@
 
 <!-- Describe what will change. Be specific about new capabilities, modifications, or removals. -->
 
+## Existing Context Reviewed
+
+<!-- List related active specs and active changes reviewed before capability selection.
+     Keep this concise: path, relevant requirement/context, and short impact note.
+     If none were found, state that explicitly. Do not copy full spec content. -->
+- `<path-or-none>`: <brief relevance and impact>
+
 ## Capabilities
 
 ### New Capabilities


### PR DESCRIPTION
## Problem

`/propose` could generate planning artifacts from the current request without reliably discovering related active specs or overlapping active changes first. That creates risk of duplicate requirements, wrong `ADDED` vs `MODIFIED` delta choices, and missed existing constraints.

## Approach

- Add an explicit Spec Context Discovery step to `.codex/skills/propose/SKILL.md` before artifact generation.
- Require lightweight term extraction from the request and optional `brief.md`.
- Require active spec search/read before capability classification.
- Require active change overlap search while excluding archived changes by default.
- Add `Existing Context Reviewed` to the proposal template.
- Align `spec-driven-custom` schema proposal/spec instructions with the new discovery contract.
- Add OpenSpec artifacts, delta spec, tasks, and scenario tests for the new `propose-skill` capability.

## Verification

- `openspec validate --changes issue-7-spec-context-discovery-propose`
- `openspec status --change issue-7-spec-context-discovery-propose`
- `openspec instructions apply --change issue-7-spec-context-discovery-propose --json`
- Verified `openspec instructions proposal/specs` includes discovery and delta-operation guidance.
- Searched active workflow guidance for `/propose`, archive-search defaults, and embedding/vector dependency drift.

## OpenSpec

- `openspec/changes/issue-7-spec-context-discovery-propose/`

## Residual Risk

- Keyword-based discovery can still miss synonyms; mitigation is explicit multi-class term extraction and clarification on ambiguous capability mapping.
- Existing unrelated local dirty files were not included in this PR: `.codex/skills/explore/SKILL.md`, `docs/ai-native-codex-workflow.md`.

## Links

- Closes #7
