### PR TITLE
Add acceptance criteria closure gate

### DIFF
--- a/.codex/skills/github-merge/SKILL.md
+++ b/.codex/skills/github-merge/SKILL.md
@@ -28,12 +28,47 @@ Accept any of:
 
 If merge strategy is not specified, use the repository default exposed by GitHub MCP/plugin or block if the default cannot be determined safely.
 
+## Acceptance Criteria Closure
+
+For GitHub-backed work with a linked issue, `/github:merge` must verify the linked issue `## Acceptance Criteria` section before human release approval, PR merge, or issue close.
+
+Parseable criteria are markdown task-list items under `## Acceptance Criteria`, such as:
+
+```md
+- [ ] Criterion text
+- [x] Criterion text
+```
+
+Fail closed when the criteria section is missing, duplicated, nested ambiguously, inside quote/code content, unsafe to parse, or unsafe to edit.
+
+For every criterion, including criteria already checked before merge time, build a coverage record:
+
+- criterion text
+- current checkbox state
+- coverage status: `covered`, `uncovered`, `ambiguous`, or `bypassed`
+- evidence source: `review.md`, `tasks.md`, tests, verification output, PR note, issue/PR comment, or explicit durable bypass
+- action taken: `checked`, `left checked`, `blocked`, or `bypassed`
+
+Do not treat `review.md: pass`, CI pass, or GitHub review approval as blanket evidence for every criterion. These can support evidence, but each criterion still needs its own mapping.
+
+When updating issue checkboxes:
+
+- Re-read the latest issue body immediately before editing.
+- Preserve all non-AC issue body text.
+- Change only checkbox markers for criteria with sufficient evidence.
+- Re-read the issue body after editing and verify expected checkbox state.
+- Block if the issue body changed unexpectedly, cannot be edited, or cannot be verified after edit.
+
+Human bypass counts only when documented in a durable GitHub or committed OpenSpec artifact, preferably a PR or issue comment that includes the criterion text and reason. Chat-only bypass is not sufficient.
+
 ## Gates
 
 Before merge, verify:
 
 - PR target is clear.
-- Linked issue is known or missing linkage is explicitly accepted by the human.
+- Linked issue is known or missing linkage is explicitly accepted and durably documented by the human.
+- Linked issue acceptance criteria have been read, mapped to criterion-level durable evidence, updated in the issue body when needed, and verified before merge.
+- Already checked acceptance criteria are also mapped to durable evidence or documented bypass.
 - If the PR is draft and every other gate passes, mark it ready for review through GitHub MCP/plugin before merging.
 - PR has no unresolved blocking comments or requested changes.
 - Required checks/CI are passing or skipped.
@@ -52,15 +87,22 @@ Before merge, verify:
 
 1. Resolve PR, repository, linked issue, and OpenSpec change.
 2. Read PR review/comment/check state through GitHub MCP/plugin.
-3. Read local `review.md` metadata.
+3. Read local `review.md` metadata and available evidence sources, including `tasks.md`, generated tests, verification output, PR verification notes, and durable bypass records.
 4. Classify checks as passing, blocked, bypassed, or N/A.
-5. If GitHub reviewer approval is required by branch protection or repository policy and missing, block and return handoff.
-6. If any other gate fails, block and return handoff.
-7. If the PR is draft, mark it ready for review through GitHub MCP/plugin.
-8. Confirm explicit human release approval unless already provided in the merge request.
-9. Merge the PR through GitHub MCP/plugin.
-10. Close the linked issue if GitHub did not auto-close it and closing is appropriate.
-11. Return the handoff to `/archive <change-name>`.
+5. Read the linked issue body and locate exactly one parseable `## Acceptance Criteria` section.
+6. Identify checked and unchecked criteria under that section.
+7. Map every criterion to criterion-level durable evidence or a durable bypass record.
+8. Re-read the issue body immediately before any checkbox update.
+9. Update only checkbox markers for verified unchecked criteria.
+10. Re-read the issue body after update and verify the expected checkbox state.
+11. If acceptance criteria are uncovered, ambiguous, unparseable, uneditable, stale after update, or checked without evidence, block and return a handoff listing the affected criteria.
+12. If GitHub reviewer approval is required by branch protection or repository policy and missing, block and return handoff.
+13. If any other gate fails, block and return handoff.
+14. If the PR is draft, mark it ready for review through GitHub MCP/plugin.
+15. Confirm explicit human release approval unless already provided in the merge request.
+16. Merge the PR through GitHub MCP/plugin.
+17. Close the linked issue if GitHub did not auto-close it and closing is appropriate.
+18. Return the handoff to `/archive <change-name>`.
 
 ## Handoff
 
@@ -74,6 +116,13 @@ Every result, including blocked states, must end with:
 - Needs human:
 - Next command:
 - Blockers:
+- Acceptance criteria:
+  - Covered:
+  - Already checked with evidence:
+  - Uncovered:
+  - Ambiguous/unparseable:
+  - Uneditable:
+  - Bypassed:
 - Links:
 ```
 
@@ -95,6 +144,10 @@ Block instead of merging when:
 - unresolved blocking comments remain
 - requested changes remain
 - local `review.md` is missing, malformed, stale, or failing
+- linked issue target is missing, multiple, conflicting, or not durably accepted by the human
+- linked issue `## Acceptance Criteria` section is missing, duplicated, ambiguous, unparseable, or unsafe to edit
+- any acceptance criterion, checked or unchecked, lacks criterion-level durable evidence or durable bypass
+- issue checkbox updates cannot be applied or verified after re-reading the issue body
 - issue close behavior is unclear and cannot be safely inferred
 
 Do not block solely because:

--- a/openspec/changes/issue-9-verify-acceptance-criteria-before-close/brief.md
+++ b/openspec/changes/issue-9-verify-acceptance-criteria-before-close/brief.md
@@ -1,0 +1,51 @@
+# Brief: Verify Acceptance Criteria Before Close
+
+## Problem
+
+`/github:create-issue` creates GitHub issues with `Acceptance Criteria` checkboxes, but the later GitHub-backed workflow does not clearly show those criteria being checked before the issue is closed.
+
+This weakens the delivery record: an issue can be closed while acceptance criteria still appear unchecked, or checkboxes can be ticked mechanically without evidence.
+
+## Goal
+
+Before `/github:merge` closes a linked issue, the workflow verifies each acceptance criterion against durable evidence and updates the issue checkbox state only for criteria that are actually covered.
+
+## Scope
+
+### In scope
+
+- Define `/github:merge` behavior for reading linked issue `## Acceptance Criteria` checkboxes before closing the issue.
+- Require mapping each criterion to evidence from `review.md`, `tasks.md`, tests, PR verification, or explicit human bypass.
+- Require updating issue body checkboxes from `[ ]` to `[x]` only after evidence review.
+- Block merge or close when parseable criteria remain unchecked without evidence or explicit accepted bypass.
+- Document handoff and blocker output for uncovered or ambiguous criteria.
+
+### Out of scope
+
+- Do not perform a full second implementation review during merge.
+- Do not auto-check all criteria merely because PR checks or review pass.
+- Do not add a new GitHub Action or external automation unless a later design explicitly requires it.
+- Do not change GitHub issue template structure beyond the existing `## Acceptance Criteria` section unless needed by the proposal.
+
+## Constraints
+
+- `/review` remains the deep implementation review gate.
+- `/github:merge` performs final acceptance-criteria closure verification, not a full review rerun.
+- Checkbox updates must be evidence-backed.
+- Missing evidence must block close or require explicit documented human bypass.
+- GitHub issue #9 is the durable intake record.
+
+## Acceptance Criteria
+
+- [ ] `/github:merge` checks linked issue Acceptance Criteria before closing the issue.
+- [ ] `/github:merge` maps each criterion to durable evidence instead of blindly ticking boxes.
+- [ ] Criteria with sufficient evidence are updated to checked state in the issue body before close.
+- [ ] Criteria without sufficient evidence block merge/close or require explicit documented human bypass.
+- [ ] Ambiguous or unparseable criteria are reported clearly in the handoff.
+- [ ] The workflow distinguishes final AC closure verification from full implementation review.
+- [ ] Specs and skill instructions document the expected evidence sources.
+
+## Links / Context
+
+- GitHub issue: https://github.com/haipd91/WorkLoop/issues/9
+- Discussion decision: merge-time checking has value only if it verifies acceptance criteria coverage before ticking checkboxes and closing the issue.

--- a/openspec/changes/issue-9-verify-acceptance-criteria-before-close/design.md
+++ b/openspec/changes/issue-9-verify-acceptance-criteria-before-close/design.md
@@ -1,0 +1,114 @@
+## Context
+
+GitHub issues created through `/github:create-issue` include `Acceptance Criteria` checkboxes. The current GitHub-backed workflow has strong review, PR, sync, and merge gates, but `/github:merge` does not explicitly verify and reflect those criteria before merging or closing the linked issue.
+
+This change is instruction/spec focused. It strengthens the durable delivery record without adding runtime automation, a GitHub Action, a custom parser library, or a new issue template.
+
+Specialist review found one critical ordering decision: acceptance-criteria verification must run before PR merge, not merely before manual issue close. A PR merge can auto-close linked issues, so post-merge verification is too late to act as a real gate.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make `/github:merge` verify linked issue acceptance criteria before PR merge and issue close.
+- Require criterion-level evidence mapping before changing `- [ ]` to `- [x]`.
+- Verify all criteria, including criteria already checked before merge time.
+- Block merge when criteria are uncovered, ambiguous, unparseable, uneditable, or unsupported by durable bypass evidence.
+- Preserve `/review` as the deep implementation review gate.
+
+**Non-Goals:**
+
+- Do not rerun a full implementation review inside `/github:merge`.
+- Do not auto-check all criteria because PR checks, review metadata, or GitHub review state passed.
+- Do not introduce a GitHub Action, custom GitHub client, parser dependency, or structured evidence database.
+- Do not redesign issue templates beyond using the existing `## Acceptance Criteria` section.
+- Do not update `/github:create-issue`, `/github:post-review`, or `/github:sync-review` unless implementation finds a direct contract gap.
+
+## Proposed Architecture
+
+`/github:merge` remains the only skill instruction that needs direct behavior change. It already owns GitHub PR/issue/review/check/merge/close operations and is the last gate before `/archive`.
+
+The refined merge flow should be:
+
+1. Resolve PR, repository, linked issue, and OpenSpec change.
+2. Read PR review/comment/check state through GitHub MCP/plugin.
+3. Read local `review.md` metadata and other available evidence sources.
+4. Read the linked issue body and locate the `## Acceptance Criteria` section.
+5. Parse task-list criteria under that section.
+6. Build a criterion-level coverage map:
+   - criterion text
+   - current checkbox state
+   - coverage status: `covered`, `uncovered`, `ambiguous`, or `bypassed`
+   - evidence source: `review.md`, `tasks.md`, tests, verification output, PR note, issue/PR comment, or documented bypass
+   - action taken: `checked`, `left checked`, `blocked`, or `bypassed`
+7. Re-read the issue body immediately before mutation.
+8. Update only checkbox markers for criteria with sufficient evidence.
+9. Re-read the issue body after mutation and verify expected checkbox state.
+10. If any criterion is uncovered, ambiguous, unparseable, uneditable, or checked without evidence, block before human release approval and before PR merge.
+11. Continue existing reviewer approval, check, draft-ready, release approval, merge, issue close, and archive handoff gates only after AC closure verification passes.
+
+Parseable criteria are markdown task-list items under the issue `## Acceptance Criteria` section. The implementation should preserve criterion text and mutate only the checkbox marker. If the section is missing, duplicated, nested ambiguously, inside quoted/code content, or otherwise unsafe to parse, `/github:merge` should fail closed and report exact ambiguity in the handoff.
+
+Bypass is an evidence type, not a shortcut. It must be documented in a durable GitHub or committed OpenSpec artifact, preferably a PR or issue comment that includes the criterion text and reason. Chat-only bypass is not sufficient.
+
+## Impact Map
+
+- `.codex/skills/github-merge/SKILL.md`: primary implementation surface. Update gates, workflow order, blocked states, and handoff expectations.
+- `openspec/specs/github-workflow/spec.md`: workflow-level behavior changes after archive: issue closure must reflect verified AC state.
+- `openspec/specs/github-orchestration-skills/spec.md`: orchestration-level behavior changes after archive: `/github:merge` must read, parse, map, update, verify, and block.
+- `openspec/specs/review-quality-gate/spec.md`: evidence source only. No metadata or archive-gate redesign.
+- GitHub issue body: mutable durable intake record; AC checkbox state is read and updated.
+- PR/review artifacts: durable evidence sources consumed by `/github:merge`.
+- `/archive`: downstream consumer of merge/issue closure evidence; no direct change planned.
+
+## Decisions
+
+### Decision 1: AC verification runs before merge
+
+`/github:merge` must complete acceptance-criteria evidence mapping and issue checkbox update before PR merge, human release approval, and issue close. This avoids merged-but-not-closable and auto-closed-with-stale-checkbox states.
+
+Alternative considered: verify only before explicit issue close after merge. Rejected because GitHub may auto-close linked issues on merge.
+
+### Decision 2: Verify all criteria, not only unchecked criteria
+
+The gate must map evidence for checked and unchecked criteria. A pre-checked criterion without evidence is still a risk because the original problem includes mechanically checked boxes.
+
+Alternative considered: trust already checked criteria. Rejected because it makes the new gate cosmetic.
+
+### Decision 3: Use criterion-level evidence mapping
+
+Each criterion needs a concrete evidence source. `review.md: pass`, completed tasks, or CI pass can support evidence, but none should blanket-satisfy every criterion without a per-criterion mapping.
+
+Alternative considered: treat global pass signals as enough. Rejected because it recreates the blind-checkbox problem.
+
+### Decision 4: Fail closed on parsing, edit, or linkage ambiguity
+
+If `/github:merge` cannot determine the linked issue, parse the AC section, update the issue body, verify the post-update body, or map evidence cleanly, it must block with a handoff instead of merging or closing.
+
+Alternative considered: merge PR and leave issue open. Rejected because it weakens the gate and creates partial delivery state.
+
+### Decision 5: Keep scope to specs and merge skill instructions
+
+No parser dependency, GitHub Action, issue template migration, or new evidence artifact is needed. The instruction-driven flow is enough for this workflow improvement.
+
+## Risks / Trade-offs
+
+- [Risk] Criteria are vague or multi-clause, making evidence mapping subjective. -> Mitigation: mark criterion `ambiguous`, block merge, and require clarification or durable bypass.
+- [Risk] Issue body update overwrites concurrent edits. -> Mitigation: re-read immediately before and after update; preserve full body text; change only expected checkbox markers; block on drift or edit conflict.
+- [Risk] A broad `review.md` pass is misused as blanket evidence. -> Mitigation: require per-criterion mapping with cited evidence.
+- [Risk] Human bypass remains chat-only. -> Mitigation: require bypass in a durable PR/issue/OpenSpec artifact before continuing.
+- [Risk] Multiple linked issues or conflicting issue references cause wrong issue verification. -> Mitigation: block on missing, multiple, or conflicting linked issue targets unless the human explicitly selects the target and records that selection durably.
+- [Risk] Merge feels heavier. -> Mitigation: keep this as final closure verification only; do not rerun full implementation review.
+
+## Open Questions
+
+- Exact parse rules can stay instruction-level for this change, but `/apply` should decide whether to document accepted task-list forms in `.codex/skills/github-merge/SKILL.md` as top-level `- [ ]` / `- [x]` items under `## Acceptance Criteria`.
+- Durable bypass location should prefer PR or issue comment. If GitHub comment write is unavailable, `/github:merge` should block unless another committed durable artifact is available.
+
+## Review Notes
+
+- Specialist agents used: Architecture, Impact, Failure Modes, Data Flow, Review and Docs.
+- Core consensus: `/github:merge` is the correct ownership boundary; `/review` remains deep review; `review.md` is evidence source only.
+- Design refinement changed the gate order from "before issue close" to stricter "before merge and issue close".
+- Design refinement added handling for already checked criteria, auto-close, stale issue body, parse ambiguity, linked issue ambiguity, and durable bypass.
+- Security and Performance agents were not run because the change does not touch auth, permissions, sensitive data, latency, throughput, or concurrency behavior beyond issue body edit race handling covered by Failure Modes and Data Flow.

--- a/openspec/changes/issue-9-verify-acceptance-criteria-before-close/proposal.md
+++ b/openspec/changes/issue-9-verify-acceptance-criteria-before-close/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+GitHub issues currently carry `Acceptance Criteria` checkboxes, but the delivery workflow does not require those criteria to be verified and checked before the linked issue is closed. This leaves issue closure evidence ambiguous and can make unchecked or mechanically checked criteria look equivalent to verified completion.
+
+## What Changes
+
+- Add a final acceptance-criteria closure gate to `/github:merge` before linked issue close.
+- Require `/github:merge` to read linked issue `## Acceptance Criteria` checkboxes and map each criterion to durable evidence.
+- Require evidence-backed criteria to be checked in the issue body before close.
+- Block merge or issue close when criteria remain uncovered, ambiguous, or unparseable unless the human explicitly accepts and documents a bypass.
+- Clarify that this gate is not a full second implementation review; `/review` remains the deep implementation review gate.
+
+## Existing Context Reviewed
+
+- `openspec/specs/github-workflow/spec.md`: Defines GitHub issues as durable intake records and merge/archive quality gates; impact is a modified quality-gate requirement for issue closure.
+- `openspec/specs/github-orchestration-skills/spec.md`: Defines `/github:merge` gates, handoff order, and GitHub operation behavior; impact is a modified merge-gate requirement and handoff behavior.
+- `openspec/specs/review-quality-gate/spec.md`: Defines `review.md` metadata and archive enforcement; impact is evidence source alignment without moving deep review responsibility into merge.
+- `openspec/changes/issue-9-verify-acceptance-criteria-before-close/brief.md`: Current issue-backed brief; this is the active change being proposed, not an overlap conflict.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `github-workflow`: Add requirement that issue acceptance criteria must be verified and reflected before GitHub-backed issue closure.
+- `github-orchestration-skills`: Add `/github:merge` behavior for acceptance-criteria evidence mapping, checkbox update, blocking, and handoff reporting.
+
+## Impact
+
+- Affected specs: `github-workflow`, `github-orchestration-skills`.
+- Affected skill instructions: `.codex/skills/github-merge/SKILL.md`.
+- No new runtime dependency, GitHub Action, data model, or external automation is required.
+- GitHub issue #9 remains the durable intake record for this change.

--- a/openspec/changes/issue-9-verify-acceptance-criteria-before-close/review.md
+++ b/openspec/changes/issue-9-verify-acceptance-criteria-before-close/review.md
@@ -1,0 +1,41 @@
+verdict: pass
+blocking_findings: none
+reviewed_ref: 6abfb4c42dd68c97b9fae48735dcf7cf7110aa26
+reviewed_diff: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+reviewed_implementation_diff: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+reviewed_paths_excluded: openspec/changes/issue-9-verify-acceptance-criteria-before-close/review.md
+reviewed_at: 2026-05-05T13:51:23Z
+
+## Findings
+
+No blocking findings.
+
+The implementation matches the approved artifacts:
+
+- `github-workflow` and `github-orchestration-skills` deltas define a pre-merge/pre-close acceptance-criteria closure gate.
+- `.codex/skills/github-merge/SKILL.md` requires criterion-level evidence mapping for checked and unchecked criteria.
+- `/github:merge` now fails closed for missing, ambiguous, unparseable, uneditable, stale, or unsupported criteria.
+- `/review` remains the deep implementation review gate; `review.md` is evidence input, not GitHub issue mutation owner.
+- The change does not introduce a dependency, GitHub Action, custom parser, data model, or issue template migration.
+
+## Tests Run
+
+- `openspec validate issue-9-verify-acceptance-criteria-before-close --strict`
+- `git diff --check`
+- Manual review against:
+  - `openspec/changes/issue-9-verify-acceptance-criteria-before-close/proposal.md`
+  - `openspec/changes/issue-9-verify-acceptance-criteria-before-close/design.md`
+  - `openspec/changes/issue-9-verify-acceptance-criteria-before-close/specs/**/*.md`
+  - `openspec/changes/issue-9-verify-acceptance-criteria-before-close/tasks.md`
+  - `openspec/changes/issue-9-verify-acceptance-criteria-before-close/tests/**/*`
+  - `.codex/skills/github-merge/SKILL.md`
+
+## Residual Risk
+
+- The AC closure behavior is instruction-driven, not backed by a runtime parser. This is intentional scope; ambiguous issue formats fail closed.
+- GitHub issue body read/update capability depends on GitHub MCP/plugin permissions at merge time. The merge skill now blocks when issue body update or verification cannot be completed.
+- This GitHub-backed change has PR evidence at https://github.com/haipd91/WorkLoop/pull/10. The passed review still must be posted to the PR before sync/merge.
+
+## Verdict
+
+Pass. No blocking findings. The implementation is ready for `/github:post-review 10`, then `/github:sync-review 10`, before `/github:merge`.

--- a/openspec/changes/issue-9-verify-acceptance-criteria-before-close/specs/github-orchestration-skills/spec.md
+++ b/openspec/changes/issue-9-verify-acceptance-criteria-before-close/specs/github-orchestration-skills/spec.md
@@ -1,0 +1,44 @@
+## ADDED Requirements
+
+### Requirement: Merge verifies acceptance criteria closure
+`/github:merge` SHALL verify linked issue acceptance criteria coverage before merging or closing the linked issue for a GitHub-backed change.
+
+#### Scenario: Merge reads linked issue criteria
+- **WHEN** `/github:merge` resolves a linked GitHub issue with a `## Acceptance Criteria` section
+- **THEN** it MUST read the issue body and identify parseable checked and unchecked criteria before merge or close
+
+#### Scenario: Merge maps criteria to evidence
+- **WHEN** `/github:merge` evaluates linked issue acceptance criteria
+- **THEN** it MUST map each criterion to durable evidence such as `review.md`, `tasks.md`, generated tests, test or verification output, PR verification notes, or explicit documented human bypass
+
+#### Scenario: Merge verifies checked criteria
+- **WHEN** `/github:merge` finds a criterion that is already checked in the linked issue body
+- **THEN** it MUST still map that criterion to durable evidence or explicit documented human bypass before merge or close
+
+#### Scenario: Merge updates verified criteria
+- **WHEN** `/github:merge` finds sufficient evidence for an unchecked acceptance criterion
+- **THEN** it MUST update the linked issue body so that criterion is checked before merge or close
+
+#### Scenario: Merge verifies issue body updates
+- **WHEN** `/github:merge` updates acceptance criteria checkbox state in the linked issue body
+- **THEN** it MUST re-read the issue body and verify the expected checkbox state before merge or close
+
+#### Scenario: Merge blocks uncovered criteria
+- **WHEN** `/github:merge` finds criteria without sufficient evidence or explicit documented bypass
+- **THEN** it MUST block merge and issue close and return a handoff listing the uncovered criteria
+
+#### Scenario: Merge reports ambiguous criteria
+- **WHEN** `/github:merge` cannot parse acceptance criteria or cannot determine which evidence covers a criterion
+- **THEN** it MUST report the ambiguity in the handoff and block merge and close unless the human explicitly accepts and durably documents a bypass
+
+#### Scenario: Merge reports uneditable criteria
+- **WHEN** `/github:merge` cannot update or verify the linked issue body after update
+- **THEN** it MUST report the issue body edit failure in the handoff and block merge and close unless the human explicitly accepts and durably documents a bypass
+
+#### Scenario: Merge avoids blind checkbox updates
+- **WHEN** PR checks, review metadata, or GitHub review state pass
+- **THEN** `/github:merge` MUST NOT blindly check all issue acceptance criteria without criterion-level evidence mapping
+
+#### Scenario: Merge records criterion coverage
+- **WHEN** `/github:merge` completes acceptance criteria verification
+- **THEN** its handoff MUST summarize covered, already checked, uncovered, ambiguous, unparseable, uneditable, and bypassed criteria with evidence links or paths when available

--- a/openspec/changes/issue-9-verify-acceptance-criteria-before-close/specs/github-workflow/spec.md
+++ b/openspec/changes/issue-9-verify-acceptance-criteria-before-close/specs/github-workflow/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: Issue acceptance criteria closure
+WorkLoop SHALL verify linked GitHub issue acceptance criteria before merging or closing a linked issue for a GitHub-backed change.
+
+#### Scenario: Criteria verified before merge and close
+- **WHEN** a GitHub-backed change is ready for merge and has a linked issue with parseable Acceptance Criteria checkboxes
+- **THEN** the workflow MUST verify each acceptance criterion against durable evidence before merging the pull request or closing the linked issue
+
+#### Scenario: Criteria evidence is reflected in issue state
+- **WHEN** an acceptance criterion is verified by durable evidence
+- **THEN** the workflow MUST update that criterion to checked state in the GitHub issue body before merge or close proceeds
+
+#### Scenario: Checked criteria still require evidence
+- **WHEN** a linked issue has an acceptance criterion already checked before merge-time verification
+- **THEN** the workflow MUST still map that criterion to durable evidence or an explicit documented bypass before merge or close proceeds
+
+#### Scenario: Uncovered criteria block merge and close
+- **WHEN** a linked issue has an acceptance criterion without sufficient durable evidence
+- **THEN** the workflow MUST block merge and issue close unless the human explicitly accepts and durably documents a bypass
+
+#### Scenario: Missing or ambiguous criteria block merge and close
+- **WHEN** the linked issue acceptance criteria section is missing, duplicated, unparseable, or unsafe to edit
+- **THEN** the workflow MUST block merge and issue close unless the human explicitly accepts and durably documents a bypass
+
+#### Scenario: Acceptance criteria closure is not deep review
+- **WHEN** the workflow verifies issue acceptance criteria before close
+- **THEN** the workflow MUST treat that verification as final closure evidence and MUST NOT replace the deep implementation review performed by `/review`

--- a/openspec/changes/issue-9-verify-acceptance-criteria-before-close/tasks.md
+++ b/openspec/changes/issue-9-verify-acceptance-criteria-before-close/tasks.md
@@ -1,0 +1,17 @@
+## 1. Spec and Workflow Contract
+
+- [x] 1.1 Verify `github-workflow` delta requires linked issue acceptance criteria verification before issue close.
+- [x] 1.2 Verify `github-orchestration-skills` delta requires `/github:merge` to read, parse, and evaluate linked issue criteria before merge or close.
+- [x] 1.3 Confirm specs distinguish acceptance-criteria closure verification from full `/review` implementation review.
+
+## 2. Merge Skill Instructions
+
+- [x] 2.1 Update `.codex/skills/github-merge/SKILL.md` gates to include acceptance-criteria coverage before linked issue close.
+- [x] 2.2 Update `/github:merge` workflow steps to read issue body, map criteria to evidence, update checked criteria, and block uncovered criteria.
+- [x] 2.3 Update `/github:merge` blocked states and handoff expectations for uncovered, ambiguous, unparseable, or uneditable acceptance criteria.
+
+## 3. Verification
+
+- [x] 3.1 Run OpenSpec validation for `issue-9-verify-acceptance-criteria-before-close`.
+- [x] 3.2 Review generated tasks/tests coverage against the brief acceptance criteria.
+- [x] 3.3 Confirm no new dependency, GitHub Action, or issue template migration was introduced.

--- a/openspec/changes/issue-9-verify-acceptance-criteria-before-close/tests/1-spec-workflow-contract.md
+++ b/openspec/changes/issue-9-verify-acceptance-criteria-before-close/tests/1-spec-workflow-contract.md
@@ -1,0 +1,48 @@
+# Test Scenario: 1. Spec Workflow Contract
+
+- Source tasks:
+  - 1.1 Verify `github-workflow` delta requires linked issue acceptance criteria verification before issue close.
+  - 1.2 Verify `github-orchestration-skills` delta requires `/github:merge` to read, parse, and evaluate linked issue criteria before merge or close.
+  - 1.3 Confirm specs distinguish acceptance-criteria closure verification from full `/review` implementation review.
+- Related requirements:
+  - `github-workflow`: Issue acceptance criteria closure
+  - `github-orchestration-skills`: Merge verifies acceptance criteria closure
+- Assumptions:
+  - This change modifies workflow/spec/skill instructions only.
+  - `/review` remains the deep implementation review gate.
+
+## Happy Path
+
+- When reading the `github-workflow` spec delta
+- Then it requires linked GitHub issue acceptance criteria to be verified against durable evidence before issue close.
+- And it requires verified criteria to be reflected in issue checkbox state.
+
+- When reading the `github-orchestration-skills` spec delta
+- Then it requires `/github:merge` to read linked issue Acceptance Criteria before merge or close.
+- And it requires `/github:merge` to map each criterion to durable evidence.
+- And it rejects blind checkbox updates from broad pass signals.
+
+## Edge Cases
+
+- A criterion is already checked before merge time.
+- The specs still require evidence mapping for that criterion, because pre-checked boxes can be mechanical or stale.
+
+- Acceptance criteria are present but ambiguous or unsafe to parse.
+- The specs require handoff reporting and fail-closed behavior rather than silent close.
+
+## Error Cases
+
+- The workflow spec only blocks issue close after merge, allowing PR merge before AC verification.
+- The orchestration spec treats `review.md: pass` as enough to check every criterion.
+- The specs imply `/review` should update GitHub issue checkboxes.
+
+## Expected Outcomes
+
+- Specs make AC closure a final merge/issue-close gate.
+- Specs keep `/review` as evidence source, not closure-state mutator.
+- Specs support blocking uncovered, ambiguous, or unsupported criteria.
+
+## Notes for Implementation
+
+- If spec wording conflicts between "block close" and "block merge or close", prefer the stricter design decision: block before merge when AC closure cannot be verified.
+- Keep delta scope to `github-workflow` and `github-orchestration-skills`.

--- a/openspec/changes/issue-9-verify-acceptance-criteria-before-close/tests/2-merge-skill-ac-flow.md
+++ b/openspec/changes/issue-9-verify-acceptance-criteria-before-close/tests/2-merge-skill-ac-flow.md
@@ -1,0 +1,68 @@
+# Test Scenario: 2. Merge Skill AC Flow
+
+- Source tasks:
+  - 2.1 Update `.codex/skills/github-merge/SKILL.md` gates to include acceptance-criteria coverage before linked issue close.
+  - 2.2 Update `/github:merge` workflow steps to read issue body, map criteria to evidence, update checked criteria, and block uncovered criteria.
+  - 2.3 Update `/github:merge` blocked states and handoff expectations for uncovered, ambiguous, unparseable, or uneditable acceptance criteria.
+- Related requirements:
+  - Merge reads linked issue criteria
+  - Merge maps criteria to evidence
+  - Merge updates verified criteria
+  - Merge blocks uncovered criteria
+  - Merge reports ambiguous criteria
+  - Merge avoids blind checkbox updates
+- Assumptions:
+  - GitHub MCP/plugin can read and update issue bodies when permissions allow.
+  - Acceptance Criteria are markdown task-list items under `## Acceptance Criteria`.
+
+## Happy Path
+
+- Given a PR, linked issue, OpenSpec change, passing review metadata, clean review feedback, and passing or N/A checks
+- And the linked issue has parseable `## Acceptance Criteria` checkboxes
+- And each criterion maps to durable evidence from `review.md`, `tasks.md`, tests, verification output, PR notes, or durable bypass
+- When `/github:merge` runs
+- Then it reads the issue body before merge.
+- And it builds a criterion-level coverage map with criterion text, checkbox state, coverage status, evidence source, and action taken.
+- And it updates only verified unchecked criteria from `[ ]` to `[x]`.
+- And it re-reads the issue body after update to verify expected state.
+- And it proceeds to release approval, merge, issue close, and archive handoff only after AC closure verification passes.
+
+## Edge Cases
+
+- A criterion is already `[x]`.
+- Then `/github:merge` still maps it to evidence and reports it as `left checked` only when evidence exists.
+
+- A PR can auto-close the linked issue on merge.
+- Then AC verification and issue body update happen before merge, preventing stale checkbox close.
+
+- The issue body changes between read and update.
+- Then `/github:merge` preserves non-AC text, changes only expected checkbox markers, re-reads, and blocks on drift or edit conflict.
+
+- Human bypass is used.
+- Then bypass is accepted only when documented in a durable PR/issue/OpenSpec artifact with criterion text and reason.
+
+## Error Cases
+
+- Linked issue is missing, multiple, or conflicts with change/PR references.
+- Then `/github:merge` blocks and asks for durable target selection.
+
+- The `## Acceptance Criteria` section is missing, duplicated, inside code/quote content, or unsafe to parse.
+- Then `/github:merge` blocks with exact ambiguity in handoff.
+
+- A criterion has no sufficient evidence.
+- Then `/github:merge` blocks before human release approval and before merge.
+
+- GitHub issue body cannot be updated or verified after update.
+- Then `/github:merge` blocks rather than merging or closing with stale criteria.
+
+## Expected Outcomes
+
+- `/github:merge` has a pre-merge AC closure gate.
+- The issue body only changes checkbox markers for verified criteria.
+- Handoff lists covered, uncovered, ambiguous, unparseable, uneditable, and bypassed criteria.
+- Blind checkbox updates from review pass, CI pass, or GitHub review approval are rejected.
+
+## Notes for Implementation
+
+- The skill instructions should be explicit enough for instruction-driven execution; no parser dependency is required.
+- Handoff should include links or paths to evidence where possible.

--- a/openspec/changes/issue-9-verify-acceptance-criteria-before-close/tests/3-verification-scope-guardrails.md
+++ b/openspec/changes/issue-9-verify-acceptance-criteria-before-close/tests/3-verification-scope-guardrails.md
@@ -1,0 +1,54 @@
+# Test Scenario: 3. Verification And Scope Guardrails
+
+- Source tasks:
+  - 3.1 Run OpenSpec validation for `issue-9-verify-acceptance-criteria-before-close`.
+  - 3.2 Review generated tasks/tests coverage against the brief acceptance criteria.
+  - 3.3 Confirm no new dependency, GitHub Action, or issue template migration was introduced.
+- Related acceptance criteria:
+  - `/github:merge` checks linked issue Acceptance Criteria before closing the issue.
+  - `/github:merge` maps each criterion to durable evidence instead of blindly ticking boxes.
+  - Criteria with sufficient evidence are updated to checked state in the issue body before close.
+  - Criteria without sufficient evidence block merge/close or require explicit documented human bypass.
+  - Ambiguous or unparseable criteria are reported clearly in the handoff.
+  - The workflow distinguishes final AC closure verification from full implementation review.
+  - Specs and skill instructions document the expected evidence sources.
+- Assumptions:
+  - Scenario tests are used because no clear test framework was detected in this repository.
+
+## Happy Path
+
+- When implementation finishes
+- Then `openspec validate issue-9-verify-acceptance-criteria-before-close --strict` passes.
+- And `tasks.md` checkboxes are complete.
+- And tests cover workflow contract, merge skill AC flow, and scope guardrails.
+
+- When reviewing changed files
+- Then changes are limited to spec deltas, `.codex/skills/github-merge/SKILL.md`, and necessary OpenSpec artifacts.
+- And no new dependency, GitHub Action, data model, custom GitHub client, or issue template migration appears.
+
+## Edge Cases
+
+- Implementation adds cross-references to `/github:create-issue`, `/github:post-review`, or `/github:sync-review`.
+- Then those changes are accepted only if they are narrow evidence/context references and do not move closure mutation away from `/github:merge`.
+
+- Implementation documents parseable checklist forms.
+- Then it keeps the rule instruction-level and fails closed on unsupported formats.
+
+## Error Cases
+
+- OpenSpec validation fails.
+- The tests do not cover checked-but-unsupported criteria, auto-close ordering, uneditable issue body, ambiguous criteria, and durable bypass.
+- Implementation introduces a GitHub Action, parser dependency, issue template migration, or new evidence database.
+- Implementation makes `/review` responsible for editing GitHub issue checkboxes.
+- Implementation allows chat-only bypass.
+
+## Expected Outcomes
+
+- Verification proves the planning artifacts and skill instructions satisfy the issue #9 acceptance criteria.
+- Scope stays small and instruction-driven.
+- `/apply` has concrete scenario coverage before implementation starts.
+
+## Notes for Implementation
+
+- Do not run implementation directly from `/tdd`.
+- Use these scenarios as review checklist input during `/apply` and `/review`.


### PR DESCRIPTION
## Problem

GitHub issues created by `/github:create-issue` include Acceptance Criteria checkboxes, but `/github:merge` did not require those criteria to be verified and reflected before merge/issue close.

## Approach

- Added an OpenSpec change for issue #9.
- Added spec deltas for `github-workflow` and `github-orchestration-skills`.
- Refined `/github:merge` instructions so acceptance criteria verification runs before human release approval, PR merge, or issue close.
- Required criterion-level evidence mapping for checked and unchecked criteria.
- Required issue checkbox update and re-read verification.
- Added fail-closed blockers for uncovered, ambiguous, unparseable, uneditable, stale, or unsupported criteria.
- Kept `/review` as the deep implementation review gate.

## Verification

- `openspec validate issue-9-verify-acceptance-criteria-before-close --strict`
- `git diff --check`
- Scenario tests created under `openspec/changes/issue-9-verify-acceptance-criteria-before-close/tests/`
- Confirmed no `.github` directory exists, so no GitHub Action was introduced.

## OpenSpec

- `openspec/changes/issue-9-verify-acceptance-criteria-before-close`

## Residual Risk

- The AC parsing/update behavior is instruction-driven, not a runtime parser. Ambiguous formats intentionally fail closed.
- GitHub issue body editing depends on connector/API permissions at merge time.

## Links

- Closes #9
